### PR TITLE
feat!: Body::TriMesh implementation

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -49,6 +49,11 @@ pub enum Body {
         /// In 2d the `z` axis is ignored
         half_extends: Vec3,
     },
+
+    TriMesh {
+        positions: Vec<Vec3>,
+        indices: Vec<[u32; 3]>,
+    },
 }
 
 /// An event fired when the collision state between two entities changed

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -50,8 +50,12 @@ pub enum Body {
         half_extends: Vec3,
     },
 
+    /// A triangle mesh shape
     TriMesh {
+        /// A vector of Vec3 positions
         positions: Vec<Vec3>,
+
+        /// A vector of &[u32; 3] each u32 represents an indice of a position in the positions vector
         indices: Vec<[u32; 3]>,
     },
 }

--- a/debug/src/lib.rs
+++ b/debug/src/lib.rs
@@ -55,7 +55,7 @@ impl Plugin for DebugPlugin {
         app.insert_resource(DebugMaterial::from(self.0))
             .init_resource::<DebugEntityMap>()
             .add_stage_before(
-                bevy_app::stage::POST_UPDATE,
+                bevy_app::CoreStage::PostUpdate,
                 "heron-debug",
                 SystemStage::single_threaded(),
             )

--- a/rapier/src/bodies.rs
+++ b/rapier/src/bodies.rs
@@ -176,9 +176,9 @@ fn cuboid_builder(half_extends: Vec3) -> ColliderBuilder {
 #[inline]
 #[cfg(feature = "3d")]
 fn trimesh_builder(vertices: Vec<Vec3>, indices: Vec<[u32; 3]>) -> ColliderBuilder {
-    let nalgebra_points: Vec<Point3<f32>> = vertices.into_bevy();
+    let points: Vec<Point3<f32>> = vertices.into_rapier();
 
-    ColliderBuilder::trimesh(nalgebra_points, indices)
+    ColliderBuilder::trimesh(points, indices)
 }
 
 #[cfg(test)]
@@ -234,5 +234,10 @@ mod tests {
         assert_eq!(capsule.segment.a.z, 0.0);
         #[cfg(feature = "3d")]
         assert_eq!(capsule.segment.b.z, 0.0);
+    }
+
+    #[test]
+    fn build_trimesh() {
+        todo!()
     }
 }

--- a/rapier/src/bodies.rs
+++ b/rapier/src/bodies.rs
@@ -4,6 +4,7 @@ use bevy_transform::prelude::*;
 use fnv::FnvHashMap;
 
 use heron_core::{Body, Restitution, Velocity};
+use rapier3d::na::Point3;
 
 use crate::convert::{IntoBevy, IntoRapier};
 use crate::rapier::dynamics::{JointSet, RigidBodyBuilder, RigidBodyHandle, RigidBodySet};
@@ -156,6 +157,7 @@ fn collider_builder(body: &Body) -> ColliderBuilder {
             radius,
         } => ColliderBuilder::capsule_y(*half_height, *radius),
         Body::Cuboid { half_extends } => cuboid_builder(*half_extends),
+        Body::TriMesh { positions, indices } => trimesh_builder(positions.clone(), indices.clone()),
     }
 }
 
@@ -169,6 +171,14 @@ fn cuboid_builder(half_extends: Vec3) -> ColliderBuilder {
 #[cfg(feature = "3d")]
 fn cuboid_builder(half_extends: Vec3) -> ColliderBuilder {
     ColliderBuilder::cuboid(half_extends.x, half_extends.y, half_extends.z)
+}
+
+#[inline]
+#[cfg(feature = "3d")]
+fn trimesh_builder(vertices: Vec<Vec3>, indices: Vec<[u32; 3]>) -> ColliderBuilder {
+    let nalgebra_points: Vec<Point3<f32>> = vertices.into_bevy();
+
+    ColliderBuilder::trimesh(nalgebra_points, indices)
 }
 
 #[cfg(test)]

--- a/rapier/src/convert.rs
+++ b/rapier/src/convert.rs
@@ -6,6 +6,7 @@
 //! with implementations for bevy and rapier types
 
 use bevy_math::prelude::*;
+use rapier3d::na::Point3;
 
 use crate::nalgebra::{self, Quaternion, UnitComplex, UnitQuaternion, Vector2, Vector3};
 use crate::rapier::math::{Isometry, Translation, Vector};
@@ -30,6 +31,14 @@ impl IntoBevy<Vec3> for Vector2<f32> {
 impl IntoBevy<Vec3> for Vector3<f32> {
     fn into_bevy(self) -> Vec3 {
         Vec3::new(self.x, self.y, self.z)
+    }
+}
+
+impl IntoBevy<Vec<Point3<f32>>> for Vec<Vec3> {
+    fn into_bevy(self) -> Vec<Point3<f32>> {
+        self.iter()
+            .map(|v| Point3::<f32>::new(v.x, v.y, v.z))
+            .collect()
     }
 }
 

--- a/rapier/src/convert.rs
+++ b/rapier/src/convert.rs
@@ -34,14 +34,6 @@ impl IntoBevy<Vec3> for Vector3<f32> {
     }
 }
 
-impl IntoBevy<Vec<Point3<f32>>> for Vec<Vec3> {
-    fn into_bevy(self) -> Vec<Point3<f32>> {
-        self.iter()
-            .map(|v| Point3::<f32>::new(v.x, v.y, v.z))
-            .collect()
-    }
-}
-
 impl IntoBevy<Vec3> for Translation<f32> {
     fn into_bevy(self) -> Vec3 {
         self.vector.into_bevy()
@@ -118,6 +110,18 @@ impl IntoRapier<f32> for AxisAngle {
 impl IntoRapier<Vector3<f32>> for AxisAngle {
     fn into_rapier(self) -> Vector3<f32> {
         Vec3::from(self).into_rapier()
+    }
+}
+
+impl IntoRapier<Point3<f32>> for Vec3 {
+    fn into_rapier(self) -> Point3<f32> {
+        Point3::new(self.x, self.y, self.z)
+    }
+}
+
+impl IntoRapier<Vec<Point3<f32>>> for Vec<Vec3> {
+    fn into_rapier(self) -> Vec<Point3<f32>> {
+        self.iter().map(|v| v.into_rapier()).collect()
     }
 }
 

--- a/rapier/src/lib.rs
+++ b/rapier/src/lib.rs
@@ -117,7 +117,7 @@ impl Plugin for RapierPlugin {
             .insert_resource(ColliderSet::new())
             .insert_resource(JointSet::new())
             .add_stage_after(
-                bevy_app::stage::POST_UPDATE,
+                bevy_app::CoreStage::PostUpdate,
                 stage::PRE_STEP,
                 SystemStage::single_threaded()
                     .with_system(bodies::remove.system())

--- a/rapier/tests/events.rs
+++ b/rapier/tests/events.rs
@@ -21,7 +21,7 @@ fn test_app() -> App {
             parameters: IntegrationParameters::default(),
         })
         .add_system_to_stage(
-            bevy::app::stage::POST_UPDATE,
+            bevy::app::CoreStage::PostUpdate,
             bevy::transform::transform_propagate_system::transform_propagate_system.system(),
         );
     builder.app


### PR DESCRIPTION
Opening this as a draft for https://github.com/jcornaz/heron/issues/41 and as a place to ask for help with potential issues regarding it.

In it's current state i'm faced with the following errors.

`thread '<unnamed>' panicked at 'index out of bounds: the len is 128 but the index is 128', C:\Users\domen\.cargo\registry\src\github.com-1ecc6299db9ec823\rapier3d-0.5.0\src\dynamics\solver\interaction_groups.rs:89:21`

I noticed that this feature is under the 'parallel' feature and tried to disable it. Once I did that I got the following error.

`thread 'main' panicked at 'assertion failed: proxy.aabb.mins[dim] <= self.max_bound', C:\Users\domen\.cargo\registry\src\github.com-1ecc6299db9ec823\rapier3d-0.5.0\src\geometry\broad_phase_multi_sap.rs:171:13`

As of now all the code required to produce the Vec<Vec3> and Vec<[u32; 3]> pair from Asset<Mesh> lives in my project https://github.com/Dmajster/radwars. So if you wish to reproduce this errors or help out I think this would be the fastest path.

 I also think this would be a great feature to move this into Heron down the road.