### PR TITLE
feat!: Provide stage to allow running systems before/after each physics step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,17 +12,17 @@ The format is inspired from [Keep a Changelog], and this project adheres to [Sem
 
 ### ⚠ Physics update stage and `add_physics_system`
 
-The physics steps run at a fixed rate (60 updates per second by default). They are therefore not in sync with the frame update (that runs as many times per second as possible).
+The physics step run at a fixed rate (60 updates per second by default). Therefore, it is not in sync with the frame update (that runs as many times per second as possible).
 
-But a user may want (and sometime have to) run system synchronously with the physics step. Generally either before (when modifying position/velocities) or after the physiscs step (when reading the output).
+But a user may want to (and sometime have to) run system synchronously with the physics step.
 
-This PR exposes the following stages:
-* `stage::ROOT`  **schedule** stage that runs at a fixed rate (60 updates per second by default)
-* `stage::UPDATE` a **child** (parallel) system stage that runs before the physics step.
+This is why two stages are now public:
+* `stage::ROOT`: the root **schedule** stage that contains the physics step and run at a fixed rate (60 updates per second by default)
+* `stage::UPDATE`: a **child** (parallel) system stage that runs before each physics step
 
-It also add the `add_physiscs_system` extension function on `AppBuilder`: to make simpler to add systems that should be synchronized with the physics steps.
+It also add the `add_physics_system` extension function on `AppBuilder`. So that it is still simple to add systems that should be synchronized with the physics step.
 
-**This is a breaking change:** Updating the transforms/velocities or any other physics component of rigid bodies must now be done in the physics update stage. Make sure to add this systems using the new `add_physics_system` extension function on `AppBuilder`
+**This is a breaking change:** Updating the transforms/velocities or any other physics component of rigid bodies must now be done in the physics update stage. Make sure to add theses systems using the new `add_physics_system` extension function on `AppBuilder`
 
 
 ### ⚠ New `PhysicMaterial` component that replaces `Restitution` (breaking)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,19 @@ The format is inspired from [Keep a Changelog], and this project adheres to [Sem
 
 ## [Unreleased]
 
-### ⚠ Dependency requirements updated (breaking)
+### ⚠ Physics update stage and `add_physics_system`
 
-The required version of rapier is bumped to ^0.6.1
+The physics steps run at a fixed rate (60 updates per second by default). They are therefore not in sync with the frame update (that runs as many times per second as possible).
+
+But a user may want (and sometime have to) run system synchronously with the physics step. Generally either before (when modifying position/velocities) or after the physiscs step (when reading the output).
+
+This PR exposes the following stages:
+* `stage::ROOT`  **schedule** stage that runs at a fixed rate (60 updates per second by default)
+* `stage::UPDATE` a **child** (parallel) system stage that runs before the physics step.
+
+It also add the `add_physiscs_system` extension function on `AppBuilder`: to make simpler to add systems that should be synchronized with the physics steps.
+
+**This is a breaking change:** Updating the transforms/velocities or any other physics component of rigid bodies must now be done in the physics update stage. Make sure to add this systems using the new `add_physics_system` extension function on `AppBuilder`
 
 
 ### ⚠ New `PhysicMaterial` component that replaces `Restitution` (breaking)
@@ -22,6 +32,12 @@ There is now a `PhysicMaterial` component which can be used to define both the r
 In the future it will be extended to define more physics properties, like the friction.
 
 Since the restitution is now defined in `PhysicMaterial`, the `Restitution` component has been removed.
+
+
+### ⚠ Dependency requirements updated (breaking)
+
+The required version of rapier is bumped to ^0.6.1
+
 
 ### Public constructor to `BodyHandle`
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,6 +10,8 @@ repository = "https://github.com/jcornaz/heron/"
 [dependencies]
 bevy_math = "^0.4.0"
 bevy_ecs = "^0.4.0"
+bevy_core = "^0.4.0"
+bevy_app = "^0.4.0"
 
 [dev-dependencies]
 bevy = { version = "0.4", default-features = false }

--- a/core/src/ext.rs
+++ b/core/src/ext.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::module_name_repetitions)]
+
 //! Extensions to bevy API
 
 use bevy_app::AppBuilder;

--- a/core/src/ext.rs
+++ b/core/src/ext.rs
@@ -1,0 +1,22 @@
+//! Extensions to bevy API
+
+use bevy_app::AppBuilder;
+use bevy_ecs::{Schedule, System};
+
+/// Extensions for the app builder
+pub trait AppBuilderExt {
+    /// Add a system to the "physics update" stage, so that it runs before each physics step.
+    ///
+    /// This can be used to add systems that modify transform/velocity or other physics components.
+    ///
+    /// Typically (and by default) the physics step run at a fixed rate and are out of sync of the bevy update.
+    fn add_physics_system<S: System<In = (), Out = ()>>(&mut self, system: S) -> &mut Self;
+}
+
+impl AppBuilderExt for AppBuilder {
+    fn add_physics_system<S: System<In = (), Out = ()>>(&mut self, system: S) -> &mut Self {
+        self.stage(crate::stage::ROOT, |schedule: &mut Schedule| {
+            schedule.add_system_to_stage(crate::stage::UPDATE, system)
+        })
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -8,9 +8,11 @@ use bevy_core::FixedTimestep;
 use bevy_ecs::{Entity, Schedule, SystemStage};
 use bevy_math::Vec3;
 
+pub use ext::*;
 pub use gravity::Gravity;
 pub use velocity::{AxisAngle, Velocity};
 
+pub mod ext;
 mod gravity;
 pub mod utils;
 mod velocity;
@@ -19,15 +21,21 @@ mod velocity;
 ///
 /// That usually means they don't run each frame, and may run more than once in a single frame.
 ///
-/// Modifying a rigid body transform or any other heron component should be done in [`stage::BEFORE_PHYSICS_STEP`].
+/// In general end-users shouldn't have to deal with these stages directly.
+///
+/// Instead, it is possible to call the [`add_physiscs_system`](ext::AppBuilderExt::add_physics_system) extension function on `AppBuilder`
+/// to register systems that should run during the physics update.
 pub mod stage {
 
-    /// The root **schedule** stage
+    /// The root **[`Schedule`](bevy_ecs::Schedule)** stage
     pub const ROOT: &str = "heron-physics";
 
-    /// System stage running right before each physics step.
+    /// A **child** [`SystemStage`](bevy_ecs::SystemStage) running before each physics step.
     ///
     /// Use this stage to modify rigid-body transforms or any other physics component.
+    ///
+    /// **This is not a root stage**. So you cannot simply call `add_system_to_stage` on bevy's app builder.
+    /// Instead consider calling the [`add_physiscs_system`](crate::ext::AppBuilderExt::add_physics_system) extension function.
     pub const UPDATE: &str = "heron-before-step";
 }
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -20,13 +20,16 @@ mod velocity;
 /// Modifying a rigid body transform or any other heron component should be done in [`stage::BEFORE_PHYSICS_STEP`].
 pub mod stage {
 
-    /// Stage running right before each physics step.
+    /// The root **schedule** stage
+    pub const PHSYSICS: &str = "heron-physics";
+
+    /// System stage running right before each physics step.
     ///
     /// Use this stage to modify rigid-body transforms or any other physics component.
-    pub const BEFORE_PHYSICS_STEP: &str = "heron-before-step";
+    pub const BEFORE_STEP: &str = "heron-before-step";
 
-    /// Stage running right after each physics step.
-    pub const AFTER_PHYSICS_STEP: &str = "heron-after-step";
+    /// System stage running right after each physics step.
+    pub const AFTER_STEP: &str = "heron-after-step";
 }
 
 /// Components that defines a body subject to physics and collision

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -13,6 +13,22 @@ mod gravity;
 pub mod utils;
 mod velocity;
 
+/// Physics stages for user systems. These stages are executed once per physics step.
+///
+/// That usually means they don't run each frame, and may run more than once in a single frame.
+///
+/// Modifying a rigid body transform or any other heron component should be done in [`stage::BEFORE_PHYSICS_STEP`].
+pub mod stage {
+
+    /// Stage running right before each physics step.
+    ///
+    /// Use this stage to modify rigid-body transforms or any other physics component.
+    pub const BEFORE_PHYSICS_STEP: &str = "heron-before-step";
+
+    /// Stage running right after each physics step.
+    pub const AFTER_PHYSICS_STEP: &str = "heron-after-step";
+}
+
 /// Components that defines a body subject to physics and collision
 ///
 /// # Example

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -3,7 +3,9 @@
 
 //! Core components and resources to use Heron
 
-use bevy_ecs::Entity;
+use bevy_app::{AppBuilder, Plugin};
+use bevy_core::FixedTimestep;
+use bevy_ecs::{Entity, Schedule, SystemStage};
 use bevy_math::Vec3;
 
 pub use gravity::Gravity;
@@ -21,15 +23,63 @@ mod velocity;
 pub mod stage {
 
     /// The root **schedule** stage
-    pub const PHSYSICS: &str = "heron-physics";
+    pub const ROOT: &str = "heron-physics";
 
     /// System stage running right before each physics step.
     ///
     /// Use this stage to modify rigid-body transforms or any other physics component.
-    pub const BEFORE_STEP: &str = "heron-before-step";
+    pub const UPDATE: &str = "heron-before-step";
+}
 
-    /// System stage running right after each physics step.
-    pub const AFTER_STEP: &str = "heron-after-step";
+/// Plugin that register stage resources and components.
+///
+/// It does **NOT** enable physics behavior.
+#[derive(Debug, Copy, Clone)]
+pub struct CorePlugin {
+    /// Number of physics step per second. `None` means to run physics step as part of the application update instead.
+    pub steps_per_second: Option<f64>,
+}
+
+impl Default for CorePlugin {
+    fn default() -> Self {
+        Self::from_steps_per_second(60)
+    }
+}
+
+impl CorePlugin {
+    /// Configure how many times per second the physics world needs to be updated
+    ///
+    /// # Panics
+    ///
+    /// Panic if the number of `steps_per_second` is 0
+    #[must_use]
+    pub fn from_steps_per_second(steps_per_second: u8) -> Self {
+        assert!(
+            steps_per_second > 0,
+            "Invalid number of step per second: {}",
+            steps_per_second
+        );
+        Self {
+            steps_per_second: Some(steps_per_second.into()),
+        }
+    }
+}
+
+impl Plugin for CorePlugin {
+    fn build(&self, app: &mut AppBuilder) {
+        app.resources_mut().get_or_insert_with(Gravity::default);
+
+        app.add_stage_after(bevy_app::stage::UPDATE, crate::stage::ROOT, {
+            let mut schedule = Schedule::default();
+
+            if let Some(steps_per_second) = self.steps_per_second {
+                schedule =
+                    schedule.with_run_criteria(FixedTimestep::steps_per_second(steps_per_second))
+            }
+
+            schedule.with_stage(crate::stage::UPDATE, SystemStage::parallel())
+        });
+    }
 }
 
 /// Components that defines a body subject to physics and collision

--- a/debug/src/lib.rs
+++ b/debug/src/lib.rs
@@ -15,6 +15,8 @@ use fnv::FnvHashMap;
 #[cfg(feature = "2d")]
 mod dim2;
 
+const DEBUG_STAGE: &str = "heron-debug";
+
 /// Plugin that enables rendering of collision shapes
 #[derive(Debug, Copy, Clone)]
 pub struct DebugPlugin(Color);
@@ -54,9 +56,9 @@ impl Plugin for DebugPlugin {
     fn build(&self, app: &mut AppBuilder) {
         app.add_resource(DebugMaterial::from(self.0))
             .init_resource::<DebugEntityMap>()
-            .add_stage_before(
-                bevy_app::stage::POST_UPDATE,
-                "heron-debug",
+            .add_stage_after(
+                heron_core::stage::AFTER_PHYSICS_STEP,
+                DEBUG_STAGE,
                 SystemStage::serial(),
             )
             .add_startup_system(create_material.system());
@@ -64,13 +66,13 @@ impl Plugin for DebugPlugin {
         #[cfg(feature = "2d")]
         {
             app.add_plugin(bevy_prototype_lyon::plugin::ShapePlugin)
-                .add_system_to_stage("heron-debug", dim2::delete_debug_sprite.system())
-                .add_system_to_stage("heron-debug", dim2::replace_debug_sprite.system())
-                .add_system_to_stage("heron-debug", dim2::create_debug_sprites.system());
+                .add_system_to_stage(DEBUG_STAGE, dim2::delete_debug_sprite.system())
+                .add_system_to_stage(DEBUG_STAGE, dim2::replace_debug_sprite.system())
+                .add_system_to_stage(DEBUG_STAGE, dim2::create_debug_sprites.system());
         }
 
-        app.add_system_to_stage("heron-debug", track_debug_entities.system())
-            .add_system_to_stage("heron-debug", scale_debug_entities.system());
+        app.add_system_to_stage(DEBUG_STAGE, track_debug_entities.system())
+            .add_system_to_stage(DEBUG_STAGE, scale_debug_entities.system());
     }
 }
 

--- a/debug/src/lib.rs
+++ b/debug/src/lib.rs
@@ -57,12 +57,8 @@ impl Plugin for DebugPlugin {
 
         app.add_resource(DebugMaterial::from(self.0))
             .init_resource::<DebugEntityMap>()
-            .stage(heron_core::stage::PHSYSICS, |schedule: &mut Schedule| {
-                schedule.add_stage_after(
-                    heron_core::stage::AFTER_STEP,
-                    "heron-debug",
-                    debug_stage(),
-                )
+            .stage(heron_core::stage::ROOT, |schedule: &mut Schedule| {
+                schedule.add_stage_after(heron_core::stage::UPDATE, "heron-debug", debug_stage())
             })
             .add_startup_system(create_material.system());
     }

--- a/debug/src/lib.rs
+++ b/debug/src/lib.rs
@@ -15,8 +15,6 @@ use fnv::FnvHashMap;
 #[cfg(feature = "2d")]
 mod dim2;
 
-const DEBUG_STAGE: &str = "heron-debug";
-
 /// Plugin that enables rendering of collision shapes
 #[derive(Debug, Copy, Clone)]
 pub struct DebugPlugin(Color);

--- a/rapier/src/lib.rs
+++ b/rapier/src/lib.rs
@@ -30,22 +30,8 @@ pub mod convert;
 mod pipeline;
 mod velocity;
 
-/// Physics stages. Systems in these stages are executed once per physics step.
-///
-/// That usually means they don't run each frame, and may run more than once in a single frame.
-///
-/// Modifying a rigid body transform or any other heron component should be done in [`stage::BEFORE_PHYSICS_STEP`].
 #[allow(unused)]
-pub mod stage {
-
-    /// Stage running right before each physics step.
-    ///
-    /// Use this stage to modify rigid-body transforms or any other physics component.
-    pub const BEFORE_PHYSICS_STEP: &str = "heron-before-step";
-
-    /// Stage running right after each physics step.
-    pub const AFTER_PHYSICS_STEP: &str = "heron-after-step";
-
+mod stage {
     pub(crate) const PRE_STEP: &str = "heron-pre-step";
     pub(crate) const STEP: &str = "heron-step";
     pub(crate) const POST_STEP: &str = "heron-post-step";
@@ -136,8 +122,8 @@ impl Plugin for RapierPlugin {
                 }
 
                 schedule
-                    .with_stage(stage::BEFORE_PHYSICS_STEP, SystemStage::parallel())
-                    .with_stage(stage::PRE_STEP,
+                    .with_stage(heron_core::stage::BEFORE_PHYSICS_STEP, SystemStage::parallel())
+                    .with_stage(crate::stage::PRE_STEP,
                         SystemStage::serial()
                                     .with_system(bevy_transform::transform_propagate_system::transform_propagate_system.system())
                                     .with_system(body::remove.system())
@@ -158,7 +144,7 @@ impl Plugin for RapierPlugin {
                             .with_system(body::update_bevy_transform.system())
                             .with_system(velocity::update_velocity_component.system())
                     )
-                    .with_stage(stage::AFTER_PHYSICS_STEP, SystemStage::parallel())
+                    .with_stage(heron_core::stage::AFTER_PHYSICS_STEP, SystemStage::parallel())
             });
     }
 }

--- a/rapier/src/lib.rs
+++ b/rapier/src/lib.rs
@@ -15,7 +15,7 @@ pub extern crate rapier3d as rapier;
 
 use bevy_app::{AppBuilder, Plugin};
 use bevy_core::FixedTimestep;
-use bevy_ecs::{IntoSystem, Schedule, SystemStage};
+use bevy_ecs::{IntoChainSystem, IntoSystem, Schedule, SystemStage};
 
 use heron_core::{CollisionEvent, Gravity};
 
@@ -137,7 +137,9 @@ impl Plugin for RapierPlugin {
                     .with_stage(
                         "heron-post-step",
                         SystemStage::parallel()
-                            .with_system(body::update_bevy_transform.system())
+                            .with_system(body::update_bevy_transform.system().chain(
+                                bevy_transform::transform_propagate_system::transform_propagate_system.system()
+                            ))
                             .with_system(velocity::update_velocity_component.system())
                     )
                     .with_stage(heron_core::stage::AFTER_STEP, SystemStage::parallel())

--- a/rapier/src/lib.rs
+++ b/rapier/src/lib.rs
@@ -15,7 +15,7 @@ pub extern crate rapier3d as rapier;
 
 use bevy_app::{AppBuilder, Plugin};
 use bevy_core::FixedTimestep;
-use bevy_ecs::{IntoChainSystem, IntoSystem, Schedule, SystemStage};
+use bevy_ecs::{IntoSystem, Schedule, SystemStage};
 
 use heron_core::{CollisionEvent, Gravity};
 
@@ -155,12 +155,7 @@ impl Plugin for RapierPlugin {
                     .with_stage(
                         stage::POST_STEP,
                         SystemStage::parallel()
-                            .with_system(
-                                body::update_bevy_transform.system().chain(
-                                    bevy_transform::transform_propagate_system::transform_propagate_system
-                                        .system()
-                                )
-                            )
+                            .with_system(body::update_bevy_transform.system())
                             .with_system(velocity::update_velocity_component.system())
                     )
                     .with_stage(stage::AFTER_PHYSICS_STEP, SystemStage::parallel())

--- a/rapier/src/lib.rs
+++ b/rapier/src/lib.rs
@@ -14,10 +14,9 @@ pub extern crate rapier2d as rapier;
 pub extern crate rapier3d as rapier;
 
 use bevy_app::{AppBuilder, Plugin};
-use bevy_core::FixedTimestep;
-use bevy_ecs::{IntoChainSystem, IntoSystem, Schedule, SystemStage};
+use bevy_ecs::{IntoSystem, Schedule, SystemStage};
 
-use heron_core::{CollisionEvent, Gravity};
+use heron_core::CollisionEvent;
 
 use crate::body::HandleMap;
 use crate::rapier::dynamics::{IntegrationParameters, JointSet, RigidBodyHandle, RigidBodySet};
@@ -102,48 +101,42 @@ impl From<IntegrationParameters> for RapierPlugin {
 
 impl Plugin for RapierPlugin {
     fn build(&self, app: &mut AppBuilder) {
-        app.resources_mut().get_or_insert_with(Gravity::default);
-
-        app.init_resource::<PhysicsPipeline>()
-            .init_resource::<HandleMap>()
-            .add_event::<CollisionEvent>()
-            .add_resource(self.parameters)
-            .add_resource(BroadPhase::new())
-            .add_resource(NarrowPhase::new())
-            .add_resource(RigidBodySet::new())
-            .add_resource(ColliderSet::new())
-            .add_resource(JointSet::new())
-            .add_stage_after(bevy_app::stage::POST_UPDATE, heron_core::stage::PHSYSICS, {
-                let mut schedule = Schedule::default();
-
-                if let Some(steps_per_second) = self.step_per_second {
-                    schedule =
-                        schedule.with_run_criteria(FixedTimestep::steps_per_second(steps_per_second))
-                }
-
-                schedule
-                    .with_stage(heron_core::stage::BEFORE_STEP, SystemStage::parallel())
-                    .with_stage("heron-step",
-                        SystemStage::serial()
-                                    .with_system(bevy_transform::transform_propagate_system::transform_propagate_system.system())
-                                    .with_system(body::remove.system())
-                                    .with_system(body::recreate_collider.system())
-                                    .with_system(body::update_rapier_position.system())
-                                    .with_system(body::update_rapier_status.system())
-                                    .with_system(velocity::update_rapier_velocity.system())
-                                    .with_system(body::create.system())
-                                    .with_system(pipeline::step.system())
-                    )
-                    .with_stage(
-                        "heron-post-step",
-                        SystemStage::parallel()
-                            .with_system(body::update_bevy_transform.system().chain(
-                                bevy_transform::transform_propagate_system::transform_propagate_system.system()
-                            ))
-                            .with_system(velocity::update_velocity_component.system())
-                    )
-                    .with_stage(heron_core::stage::AFTER_STEP, SystemStage::parallel())
-            });
+        app.add_plugin(heron_core::CorePlugin {
+            steps_per_second: self.step_per_second,
+        })
+        .init_resource::<PhysicsPipeline>()
+        .init_resource::<HandleMap>()
+        .add_event::<CollisionEvent>()
+        .add_resource(self.parameters)
+        .add_resource(BroadPhase::new())
+        .add_resource(NarrowPhase::new())
+        .add_resource(RigidBodySet::new())
+        .add_resource(ColliderSet::new())
+        .add_resource(JointSet::new())
+        .stage(heron_core::stage::ROOT, |schedule: &mut Schedule| {
+            schedule
+                .add_stage(
+                    "heron-step",
+                    SystemStage::serial()
+                        .with_system(
+                            bevy_transform::transform_propagate_system::transform_propagate_system
+                                .system(),
+                        )
+                        .with_system(body::remove.system())
+                        .with_system(body::recreate_collider.system())
+                        .with_system(body::update_rapier_position.system())
+                        .with_system(body::update_rapier_status.system())
+                        .with_system(velocity::update_rapier_velocity.system())
+                        .with_system(body::create.system())
+                        .with_system(pipeline::step.system()),
+                )
+                .add_stage(
+                    "heron-post-step",
+                    SystemStage::parallel()
+                        .with_system(body::update_bevy_transform.system())
+                        .with_system(velocity::update_velocity_component.system()),
+                )
+        });
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,8 @@ pub mod rapier_plugin {
 /// Re-exports of the most commons/useful types
 pub mod prelude {
     pub use crate::{
-        AxisAngle, Body, BodyType, CollisionEvent, Gravity, PhysicMaterial, PhysicsPlugin, Velocity,
+        stage, AxisAngle, Body, BodyType, CollisionEvent, Gravity, PhysicMaterial, PhysicsPlugin,
+        Velocity,
     };
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,8 +108,8 @@ pub mod rapier_plugin {
 /// Re-exports of the most commons/useful types
 pub mod prelude {
     pub use crate::{
-        stage, AxisAngle, Body, BodyType, CollisionEvent, Gravity, PhysicMaterial, PhysicsPlugin,
-        Velocity,
+        ext::*, stage, AxisAngle, Body, BodyType, CollisionEvent, Gravity, PhysicMaterial,
+        PhysicsPlugin, Velocity,
     };
 }
 


### PR DESCRIPTION
The physics steps run at a fixed rate (60 updates per second by default). They are therefore not in sync with the frame update (that runs as many times per second as possible).

But a user may want (and sometime have to) run system synchronously with the physics step. Generally either before (when modifying position/velocities) or after the physiscs step (when reading the output).

This PR exposes the following stages:
* `stage::ROOT`  **schedule** stage that runs at a fixed rate (60 updates per second by default)
* `stage::UPDATE` a **child** (parallel) system stage that runs before the physics step. 

It also add the `add_physiscs_system` extension function on `AppBuilder`: to make simpler to add systems that should be synchronized with the physics steps.

**This is a breaking change:** Updating the transforms/velocities or any other physics component of rigid bodies must now be done in the physics update stage. Make sure to add this systems using the new `add_physics_system` extension function on `AppBuilder`