### PR TITLE
feat!: ConvexHull collision shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The format is inspired from [Keep a Changelog], and this project adheres to [Sem
 
 ## [Unreleased]
 
+### ⚠ ConvexHull collision shape
+
+There is a new variant in the `Body` enum: `ConvexHull`. It takes a list of points, and the body shape will be the
+smallest possible convex shape that includes all the given points.
+
 ### RotationConstraints component
 
 A new `RotationConstraints` component make possible to prevent rotation around the given axes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is inspired from [Keep a Changelog], and this project adheres to [Sem
 There is a new variant in the `Body` enum: `ConvexHull`. It takes a list of points, and the body shape will be the
 smallest possible convex shape that includes all the given points.
 
+Thanks @faassen
+
 ### RotationConstraints component
 
 A new `RotationConstraints` component make possible to prevent rotation around the given axes.

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -128,6 +128,12 @@ pub enum Body {
         /// In 2d the `z` axis is ignored
         half_extends: Vec3,
     },
+
+    /// A convex polygon/polyhedron shape
+    ConvexHull {
+        /// A vector of points describing the convex hull
+        points: Vec<Vec3>,
+    },
 }
 
 impl Default for Body {

--- a/debug/Cargo.toml
+++ b/debug/Cargo.toml
@@ -14,6 +14,7 @@ default = []
 
 [dependencies]
 heron_core = { path = "../core", version = "^0.2.0"}
+heron_rapier = { path = "../rapier", version = "^0.2.0"}
 bevy = { version = "^0.4.0", default-features = false, features = ["render"] }
 bevy_prototype_lyon = { version = "0.2.0", optional = true }
 fnv = "^1.0"

--- a/debug/src/dim2.rs
+++ b/debug/src/dim2.rs
@@ -123,7 +123,7 @@ fn base_builder(body: &Body) -> GeometryBuilder {
         }
         Body::ConvexHull { points } => {
             builder.add(&shapes::Polygon {
-                points: points.iter().map(|p| (*p).into()).collect(),
+                points: points.iter().cloned().map(Into::into).collect(),
                 closed: true,
             });
         }

--- a/debug/src/dim2.rs
+++ b/debug/src/dim2.rs
@@ -121,6 +121,12 @@ fn base_builder(body: &Body) -> GeometryBuilder {
                 height: 2.0 * half_extends.y,
             });
         }
+        Body::ConvexHull { points } => {
+            builder.add(&shapes::Polygon {
+                points: points.iter().map(|p| (*p).into()).collect(),
+                closed: true,
+            });
+        }
     };
 
     builder

--- a/examples/debug.rs
+++ b/examples/debug.rs
@@ -53,5 +53,6 @@ fn spawn(commands: &mut Commands) {
                 Vec3::new(50.0, 0.0, 0.0),
                 Vec3::new(-50.0, 0.0, 0.0),
             ],
-        });
+        })
+        .with(BodyType::Static);
 }

--- a/examples/debug.rs
+++ b/examples/debug.rs
@@ -42,6 +42,7 @@ fn spawn(commands: &mut Commands) {
         })
         .with(BodyType::Static);
 
+    // ConvexHull, in this case describing a triangle
     commands
         .spawn((
             Transform::from_translation(Vec3::unit_y() * 150.0),

--- a/examples/debug.rs
+++ b/examples/debug.rs
@@ -41,4 +41,17 @@ fn spawn(commands: &mut Commands) {
             half_segment: 50.0,
         })
         .with(BodyType::Static);
+
+    commands
+        .spawn((
+            Transform::from_translation(Vec3::unit_y() * 150.0),
+            GlobalTransform::default(),
+        ))
+        .with(Body::ConvexHull {
+            points: vec![
+                Vec3::new(0.0, -50.0, 0.0),
+                Vec3::new(50.0, 0.0, 0.0),
+                Vec3::new(-50.0, 0.0, 0.0),
+            ],
+        });
 }

--- a/rapier/src/body.rs
+++ b/rapier/src/body.rs
@@ -247,11 +247,8 @@ fn cuboid_builder(half_extends: Vec3) -> ColliderBuilder {
 
 #[inline]
 fn convex_hull_builder(points: &[Vec3]) -> ColliderBuilder {
-    let mut converted_points: Vec<Point<f32>> = Vec::with_capacity(points.len());
-    for point in points.iter() {
-        converted_points.push(point.into_rapier());
-    }
-    ColliderBuilder::convex_hull(converted_points.as_slice()).expect("Failed to create convex-hull")
+    let points: Vec<Point<f32>> = points.into_rapier();
+    ColliderBuilder::convex_hull(points.as_slice()).expect("Failed to create convex-hull")
 }
 
 fn body_status(body_type: BodyType) -> BodyStatus {

--- a/rapier/src/body.rs
+++ b/rapier/src/body.rs
@@ -6,11 +6,11 @@ use fnv::FnvHashMap;
 use heron_core::{Body, BodyType, PhysicMaterial, Velocity};
 
 use crate::convert::{IntoBevy, IntoRapier};
-use crate::nalgebra::{Point2, Point3};
 use crate::rapier::dynamics::{
     BodyStatus, JointSet, RigidBodyBuilder, RigidBodyHandle, RigidBodySet,
 };
 use crate::rapier::geometry::{Collider, ColliderBuilder, ColliderSet};
+use crate::rapier::math::Point;
 use crate::BodyHandle;
 
 pub(crate) type HandleMap = FnvHashMap<Entity, RigidBodyHandle>;
@@ -246,23 +246,12 @@ fn cuboid_builder(half_extends: Vec3) -> ColliderBuilder {
 }
 
 #[inline]
-#[cfg(feature = "2d")]
 fn convex_hull_builder(points: &[Vec3]) -> ColliderBuilder {
-    let mut converted_points: Vec<Point2<f32>> = vec![];
+    let mut converted_points: Vec<Point<f32>> = Vec::with_capacity(points.len());
     for point in points.iter() {
-        converted_points.push(Point2::new(point.x, point.y));
+        converted_points.push(point.into_rapier());
     }
-    ColliderBuilder::convex_hull(converted_points.as_slice()).unwrap()
-}
-
-#[inline]
-#[cfg(feature = "3d")]
-fn convex_hull_builder(points: &[Vec3]) -> ColliderBuilder {
-    let mut converted_points: Vec<Point3<f32>> = vec![];
-    for point in points.iter() {
-        converted_points.push(Point3::new(point.x, point.y, point.z));
-    }
-    ColliderBuilder::convex_hull(converted_points.as_slice()).unwrap()
+    ColliderBuilder::convex_hull(converted_points.as_slice()).expect("Failed to create convex-hull")
 }
 
 fn body_status(body_type: BodyType) -> BodyStatus {

--- a/rapier/src/body.rs
+++ b/rapier/src/body.rs
@@ -6,6 +6,7 @@ use fnv::FnvHashMap;
 use heron_core::{Body, BodyType, PhysicMaterial, Velocity};
 
 use crate::convert::{IntoBevy, IntoRapier};
+use crate::nalgebra::{Point2, Point3};
 use crate::rapier::dynamics::{
     BodyStatus, JointSet, RigidBodyBuilder, RigidBodyHandle, RigidBodySet,
 };
@@ -220,6 +221,7 @@ fn build_collider(
             radius,
         } => ColliderBuilder::capsule_y(*half_height, *radius),
         Body::Cuboid { half_extends } => cuboid_builder(*half_extends),
+        Body::ConvexHull { points } => convex_hull_builder(points.as_slice()),
     };
 
     builder = builder
@@ -241,6 +243,26 @@ fn cuboid_builder(half_extends: Vec3) -> ColliderBuilder {
 #[cfg(feature = "3d")]
 fn cuboid_builder(half_extends: Vec3) -> ColliderBuilder {
     ColliderBuilder::cuboid(half_extends.x, half_extends.y, half_extends.z)
+}
+
+#[inline]
+#[cfg(feature = "2d")]
+fn convex_hull_builder(points: &[Vec3]) -> ColliderBuilder {
+    let mut converted_points: Vec<Point2<f32>> = vec![];
+    for point in points.iter() {
+        converted_points.push(Point2::new(point.x, point.y));
+    }
+    ColliderBuilder::convex_hull(converted_points.as_slice()).unwrap()
+}
+
+#[inline]
+#[cfg(feature = "3d")]
+fn convex_hull_builder(points: &[Vec3]) -> ColliderBuilder {
+    let mut converted_points: Vec<Point3<f32>> = vec![];
+    for point in points.iter() {
+        converted_points.push(Point3::new(point.x, point.y, point.z));
+    }
+    ColliderBuilder::convex_hull(converted_points.as_slice()).unwrap()
 }
 
 fn body_status(body_type: BodyType) -> BodyStatus {

--- a/rapier/src/convert.rs
+++ b/rapier/src/convert.rs
@@ -102,6 +102,18 @@ impl IntoRapier<Point3<f32>> for Vec3 {
     }
 }
 
+impl IntoRapier<Vec<Point2<f32>>> for &[Vec3] {
+    fn into_rapier(self) -> Vec<Point2<f32>> {
+        self.iter().cloned().map(IntoRapier::into_rapier).collect()
+    }
+}
+
+impl IntoRapier<Vec<Point3<f32>>> for &[Vec3] {
+    fn into_rapier(self) -> Vec<Point3<f32>> {
+        self.iter().cloned().map(IntoRapier::into_rapier).collect()
+    }
+}
+
 impl IntoRapier<Translation<f32>> for Vec3 {
     fn into_rapier(self) -> Translation<f32> {
         <Vec3 as IntoRapier<Vector<f32>>>::into_rapier(self).into()
@@ -154,8 +166,9 @@ mod tests {
 
     #[cfg(feature = "2d")]
     mod angle2d {
-        use super::*;
         use rstest::rstest;
+
+        use super::*;
 
         #[test]
         fn negative_axis_angle_to_rapier() {

--- a/rapier/src/convert.rs
+++ b/rapier/src/convert.rs
@@ -114,6 +114,18 @@ impl IntoRapier<Vec<Point3<f32>>> for &[Vec3] {
     }
 }
 
+impl IntoBevy<Vec2> for Point2<f32> {
+    fn into_bevy(self) -> Vec2 {
+        Vec2::new(self.x, self.y)
+    }
+}
+
+impl IntoBevy<Vec<Vec2>> for &[Point2<f32>] {
+    fn into_bevy(self) -> Vec<Vec2> {
+        self.iter().cloned().map(IntoBevy::into_bevy).collect()
+    }
+}
+
 impl IntoRapier<Translation<f32>> for Vec3 {
     fn into_rapier(self) -> Translation<f32> {
         <Vec3 as IntoRapier<Vector<f32>>>::into_rapier(self).into()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,7 +124,8 @@
 //!
 //! ## See also
 //!
-//! * The different [`BodyType`] (dynamic, static, kinematic or sensor)
+//! * How to choose a [collision shape](Body)
+//! * How to define a [`BodyType`] (dynamic, static, kinematic or sensor)
 //! * How to define the world's [`Gravity`]
 //! * How to define the [`PhysicMaterial`]
 //! * How to listen to [`CollisionEvent`]


### PR DESCRIPTION
I introduce a new Body type. I've extended the debug renderer to show it as well.

See #59 for a bunch of things I'm not happy about yet. In brief summary:

* I wrote convert code outside of `convert.rs`. This also results in unused import warnings for `body.rs` when I build the demo. (I also see that this breaks the PR checks)

* it could be nice to have a better way to convert a slice of Vec3 to a slice of Vec2 in the implementation of `dim2.rs`

* building a convex hull may fail, which I've hacked around with using `unwrap()`. What would be a better error handling mechanism?
