### PR TITLE
feat: RotationContraints component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,13 @@ The format is inspired from [Keep a Changelog], and this project adheres to [Sem
 
 ## [Unreleased]
 
-The default color for debug shape is less transparent. That should make easier to see the debug shapes.
+### RotationConstraints component
+
+A new `RotationConstraints` component make possible to prevent rotation around the given axes (incl. fully lock rotation)
+
+### Others
+
+* The opacity has been increased for the default color of debug shapes.
 
 
 ## [0.2.0] - 2021-03-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is inspired from [Keep a Changelog], and this project adheres to [Sem
 
 ### RotationConstraints component
 
-A new `RotationConstraints` component make possible to prevent rotation around the given axes (incl. fully lock rotation)
+A new `RotationConstraints` component make possible to prevent rotation around the given axes.
 
 ### Others
 

--- a/core/src/constraints.rs
+++ b/core/src/constraints.rs
@@ -1,0 +1,74 @@
+use bevy::reflect::Reflect;
+
+/// Component that restrict the rotations caused by forces
+///
+/// Note that angular velocity may still be applied programmatically.
+#[derive(Debug, Copy, Clone, Reflect)]
+pub struct RotationConstraints {
+    /// Set to true to prevent rotations around the x axis
+    pub allow_x: bool,
+
+    /// Set to true to prevent rotations around the y axis
+    pub allow_y: bool,
+
+    /// Set to true to prevent rotations around the Z axis
+    pub allow_z: bool,
+}
+
+impl Default for RotationConstraints {
+    fn default() -> Self {
+        Self::allow()
+    }
+}
+
+impl RotationConstraints {
+    /// Lock rotations around all axes
+    #[must_use]
+    pub fn lock() -> Self {
+        Self {
+            allow_x: false,
+            allow_y: false,
+            allow_z: false,
+        }
+    }
+
+    /// Allow rotations around all axes
+    #[must_use]
+    pub fn allow() -> Self {
+        Self {
+            allow_x: true,
+            allow_y: true,
+            allow_z: true,
+        }
+    }
+
+    /// Allow rotation around the x axis only (and prevent rotating around the other axes)
+    #[must_use]
+    pub fn restrict_to_x_only() -> Self {
+        Self {
+            allow_x: true,
+            allow_y: false,
+            allow_z: false,
+        }
+    }
+
+    /// Allow rotation around the y axis only (and prevent rotating around the other axes)
+    #[must_use]
+    pub fn restrict_to_y_only() -> Self {
+        Self {
+            allow_x: false,
+            allow_y: true,
+            allow_z: false,
+        }
+    }
+
+    /// Allow rotation around the z axis only (and prevent rotating around the other axes)
+    #[must_use]
+    pub fn restrict_to_z_only() -> Self {
+        Self {
+            allow_x: false,
+            allow_y: false,
+            allow_z: true,
+        }
+    }
+}

--- a/core/src/constraints.rs
+++ b/core/src/constraints.rs
@@ -1,8 +1,22 @@
 use bevy::reflect::Reflect;
 
-/// Component that restrict the rotations caused by forces
+/// Component that restrict what rotations can be caused by forces.
 ///
-/// Note that angular velocity may still be applied programmatically.
+/// Note that angular velocity may still be applied programmatically. This only restrict how rotation
+/// can change when force/torques are applied.
+///
+/// # Example
+///
+/// ```
+/// # use bevy::prelude::*;
+/// # use heron_core::*;
+///
+/// fn spawn(commands: &mut Commands) {
+///     commands.spawn(todo!("Spawn your sprite/mesh, incl. at least a GlobalTransform"))
+///         .with(Body::Sphere { radius: 1.0 })
+///         .with(RotationConstraints::lock()); // Prevent rotation caused by forces
+/// }
+/// ```
 #[derive(Debug, Copy, Clone, Reflect)]
 pub struct RotationConstraints {
     /// Set to true to prevent rotations around the x axis

--- a/core/src/ext.rs
+++ b/core/src/ext.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::module_name_repetitions)]
-
 //! Extensions to bevy API
 
 use bevy::app::AppBuilder;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,5 +1,6 @@
 #![deny(future_incompatible, nonstandard_style)]
 #![warn(missing_docs, rust_2018_idioms, clippy::pedantic)]
+#![allow(clippy::module_name_repetitions)]
 
 //! Core components and resources to use Heron
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -6,10 +6,12 @@
 use bevy::core::FixedTimestep;
 use bevy::prelude::*;
 
+pub use constraints::RotationConstraints;
 pub use ext::*;
 pub use gravity::Gravity;
 pub use velocity::{AxisAngle, Velocity};
 
+mod constraints;
 pub mod ext;
 mod gravity;
 pub mod utils;
@@ -275,43 +277,6 @@ impl Default for PhysicMaterial {
         Self {
             restitution: Self::PERFECTLY_INELASTIC_RESTITUTION,
             density: 1.0,
-        }
-    }
-}
-
-/// Component that restrict the rotations caused by forces
-///
-/// Note that angular velocity may still be applied programmatically.
-#[derive(Debug, Copy, Clone, Reflect)]
-pub struct RotationConstraints {
-    /// Set to true to prevent rotations around the x axis
-    pub allow_x: bool,
-
-    /// Set to true to prevent rotations around the y axis
-    pub allow_y: bool,
-
-    /// Set to true to prevent rotations around the Z axis
-    pub allow_z: bool,
-}
-
-impl Default for RotationConstraints {
-    fn default() -> Self {
-        Self {
-            allow_x: true,
-            allow_y: true,
-            allow_z: true,
-        }
-    }
-}
-
-impl RotationConstraints {
-    /// Lock rotations around all axes
-    #[must_use]
-    pub fn lock() -> Self {
-        Self {
-            allow_x: false,
-            allow_y: false,
-            allow_z: false,
         }
     }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -79,6 +79,7 @@ impl Plugin for CorePlugin {
             .register_type::<BodyType>()
             .register_type::<PhysicMaterial>()
             .register_type::<Velocity>()
+            .register_type::<RotationConstraints>()
             .add_stage_after(bevy::app::stage::UPDATE, crate::stage::ROOT, {
                 let mut schedule = Schedule::default();
 
@@ -218,6 +219,7 @@ impl BodyType {
 ///         }   
 ///     }   
 /// }
+/// ```
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum CollisionEvent {
     /// The two entities started to collide
@@ -273,6 +275,43 @@ impl Default for PhysicMaterial {
         Self {
             restitution: Self::PERFECTLY_INELASTIC_RESTITUTION,
             density: 1.0,
+        }
+    }
+}
+
+/// Component that restrict the rotations caused by forces
+///
+/// Note that angular velocity may still be applied programmatically.
+#[derive(Debug, Copy, Clone, Reflect)]
+pub struct RotationConstraints {
+    /// Set to true to prevent rotations around the x axis
+    pub allow_x: bool,
+
+    /// Set to true to prevent rotations around the y axis
+    pub allow_y: bool,
+
+    /// Set to true to prevent rotations around the Z axis
+    pub allow_z: bool,
+}
+
+impl Default for RotationConstraints {
+    fn default() -> Self {
+        Self {
+            allow_x: true,
+            allow_y: true,
+            allow_z: true,
+        }
+    }
+}
+
+impl RotationConstraints {
+    /// Lock rotations around all axes
+    #[must_use]
+    pub fn lock() -> Self {
+        Self {
+            allow_x: false,
+            allow_y: false,
+            allow_z: false,
         }
     }
 }

--- a/rapier/src/body.rs
+++ b/rapier/src/body.rs
@@ -3,7 +3,7 @@ use bevy::math::prelude::*;
 use bevy::transform::prelude::*;
 use fnv::FnvHashMap;
 
-use heron_core::{Body, BodyType, PhysicMaterial, Velocity};
+use heron_core::{Body, BodyType, PhysicMaterial, RotationConstraints, Velocity};
 
 use crate::convert::{IntoBevy, IntoRapier};
 use crate::rapier::dynamics::{
@@ -29,16 +29,35 @@ pub(crate) fn create(
             Option<&BodyType>,
             Option<&Velocity>,
             Option<&PhysicMaterial>,
+            Option<&RotationConstraints>,
         ),
         Without<BodyHandle>,
     >,
 ) {
-    for (entity, body, transform, body_type, velocity, material) in query.iter() {
+    for (entity, body, transform, body_type, velocity, material, restrict_rotation) in query.iter()
+    {
         let body_type = body_type.cloned().unwrap_or_default();
 
         let mut builder = RigidBodyBuilder::new(body_status(body_type))
             .user_data(entity.to_bits().into())
             .position((transform.translation, transform.rotation).into_rapier());
+
+        #[allow(unused_variables)]
+        if let Some(RotationConstraints {
+            allow_x,
+            allow_y,
+            allow_z,
+        }) = restrict_rotation.cloned()
+        {
+            #[cfg(feature = "2d")]
+            if !allow_z {
+                builder = builder.lock_rotations();
+            }
+            #[cfg(feature = "3d")]
+            {
+                builder = builder.restrict_rotations(allow_x, allow_y, allow_z);
+            }
+        }
 
         if let Some(v) = velocity {
             #[cfg(feature = "2d")]

--- a/rapier/src/body.rs
+++ b/rapier/src/body.rs
@@ -109,7 +109,7 @@ pub(crate) fn remove_invalid_bodies(
     }
 
     for entity in removed.removed::<RotationConstraints>() {
-        if let Some((entity, handle)) = removed.get(*entity).ok() {
+        if let Ok((entity, handle)) = removed.get(*entity) {
             bodies.remove(handle.rigid_body, &mut colliders, &mut joints);
             commands.remove_one::<BodyHandle>(entity);
         }

--- a/rapier/src/body.rs
+++ b/rapier/src/body.rs
@@ -34,7 +34,8 @@ pub(crate) fn create(
         Without<BodyHandle>,
     >,
 ) {
-    for (entity, body, transform, body_type, velocity, material, restrict_rotation) in query.iter()
+    for (entity, body, transform, body_type, velocity, material, rotation_constraints) in
+        query.iter()
     {
         let body_type = body_type.cloned().unwrap_or_default();
 
@@ -47,7 +48,7 @@ pub(crate) fn create(
             allow_x,
             allow_y,
             allow_z,
-        }) = restrict_rotation.cloned()
+        }) = rotation_constraints.cloned()
         {
             #[cfg(feature = "2d")]
             if !allow_z {

--- a/rapier/src/body.rs
+++ b/rapier/src/body.rs
@@ -95,6 +95,27 @@ pub(crate) fn create(
     }
 }
 
+pub(crate) fn remove_invalid_bodies(
+    commands: &mut Commands,
+    mut bodies: ResMut<'_, RigidBodySet>,
+    mut colliders: ResMut<'_, ColliderSet>,
+    mut joints: ResMut<'_, JointSet>,
+    changed: Query<'_, (Entity, &BodyHandle), Changed<RotationConstraints>>,
+    removed: Query<'_, (Entity, &BodyHandle), Without<RotationConstraints>>,
+) {
+    for (entity, handle) in changed.iter() {
+        bodies.remove(handle.rigid_body, &mut colliders, &mut joints);
+        commands.remove_one::<BodyHandle>(entity);
+    }
+
+    for entity in removed.removed::<RotationConstraints>() {
+        if let Some((entity, handle)) = removed.get(*entity).ok() {
+            bodies.remove(handle.rigid_body, &mut colliders, &mut joints);
+            commands.remove_one::<BodyHandle>(entity);
+        }
+    }
+}
+
 #[allow(clippy::type_complexity)]
 pub(crate) fn recreate_collider(
     mut bodies: ResMut<'_, RigidBodySet>,

--- a/rapier/src/lib.rs
+++ b/rapier/src/lib.rs
@@ -117,7 +117,7 @@ impl Plugin for RapierPlugin {
             schedule
                 .add_stage(
                     "heron-remove-invalid-bodies",
-                    SystemStage::serial().with_system(body::remove_invalid_bodies.system()),
+                    SystemStage::serial().with_system(body::remove_bodies.system()),
                 )
                 .add_stage(
                     "heron-pre-step",
@@ -127,7 +127,6 @@ impl Plugin for RapierPlugin {
                                 .system(),
                         )
                         .with_system(body::remove.system())
-                        .with_system(body::recreate_collider.system())
                         .with_system(body::update_rapier_position.system())
                         .with_system(velocity::update_rapier_velocity.system())
                         .with_system(body::update_rapier_status.system())

--- a/rapier/src/lib.rs
+++ b/rapier/src/lib.rs
@@ -116,6 +116,10 @@ impl Plugin for RapierPlugin {
         .stage(heron_core::stage::ROOT, |schedule: &mut Schedule| {
             schedule
                 .add_stage(
+                    "heron-remove-invalid-bodies",
+                    SystemStage::serial().with_system(body::remove_invalid_bodies.system()),
+                )
+                .add_stage(
                     "heron-pre-step",
                     SystemStage::serial()
                         .with_system(

--- a/rapier/tests/constraints.rs
+++ b/rapier/tests/constraints.rs
@@ -65,7 +65,6 @@ fn rotation_can_be_locked_at_creation() {
 }
 
 #[test]
-#[ignore]
 fn rotation_can_be_locked_after_creation() {
     let mut app = test_app();
 
@@ -89,5 +88,32 @@ fn rotation_can_be_locked_after_creation() {
             .unwrap()
             .effective_world_inv_inertia_sqrt,
         0.0
+    );
+}
+
+#[test]
+fn rotation_is_unlocked_if_component_is_removed() {
+    let mut app = test_app();
+
+    let entity = app.world.spawn((
+        GlobalTransform::default(),
+        Body::Sphere { radius: 10.0 },
+        RotationConstraints::lock(),
+    ));
+
+    app.update();
+
+    app.world.remove_one::<RotationConstraints>(entity).unwrap();
+
+    app.update();
+
+    let bodies = app.resources.get::<RigidBodySet>().unwrap();
+
+    assert!(
+        bodies
+            .get(app.world.get::<BodyHandle>(entity).unwrap().rigid_body())
+            .unwrap()
+            .effective_world_inv_inertia_sqrt
+            > 0.0
     );
 }

--- a/rapier/tests/constraints.rs
+++ b/rapier/tests/constraints.rs
@@ -1,0 +1,65 @@
+#![cfg(all(
+    any(feature = "2d", feature = "3d"),
+    not(all(feature = "2d", feature = "3d")),
+))]
+
+use bevy::core::CorePlugin;
+use bevy::prelude::*;
+use bevy::reflect::TypeRegistryArc;
+
+use heron_core::{Body, PhysicMaterial};
+use heron_rapier::convert::IntoBevy;
+use heron_rapier::rapier::dynamics::{IntegrationParameters, RigidBodySet};
+use heron_rapier::rapier::math::AngVector;
+use heron_rapier::{BodyHandle, RapierPlugin};
+
+fn test_app() -> App {
+    let mut builder = App::build();
+    builder
+        .init_resource::<TypeRegistryArc>()
+        .add_plugin(CorePlugin)
+        .add_plugin(RapierPlugin {
+            step_per_second: None,
+            parameters: IntegrationParameters::default(),
+        });
+    builder.app
+}
+
+#[test]
+fn rotation_is_not_constrained_without_the_component() {
+    let mut app = test_app();
+
+    let entity = app
+        .world
+        .spawn((GlobalTransform::default(), Body::Sphere { radius: 10.0 }));
+
+    app.update();
+
+    let bodies = app.resources.get::<RigidBodySet>().unwrap();
+    let body = bodies
+        .get(app.world.get::<BodyHandle>(entity).unwrap().rigid_body())
+        .unwrap();
+
+    let inv_angular_inertia: Vec3 =
+        vec3_from_angle_vector(body.mass_properties().inv_principal_inertia_sqrt);
+
+    let inv_angular_inertia: Vec3 = inv_angular_inertia.into();
+
+    #[cfg(feature = "3d")]
+    assert!(inv_angular_inertia.x > 0.0);
+
+    #[cfg(feature = "3d")]
+    assert!(inv_angular_inertia.y > 0.0);
+
+    assert!(inv_angular_inertia.z > 0.0);
+}
+
+#[cfg(feature = "2d")]
+fn vec3_from_angle_vector(vector: AngVector<f32>) -> Vec3 {
+    Vec3::unit_z() * vector
+}
+
+#[cfg(feature = "3d")]
+fn vec3_from_angle_vector(vector: AngVector<f32>) -> Vec3 {
+    vector.into_bevy()
+}

--- a/rapier/tests/constraints.rs
+++ b/rapier/tests/constraints.rs
@@ -1,16 +1,11 @@
-#![cfg(all(
-    any(feature = "2d", feature = "3d"),
-    not(all(feature = "2d", feature = "3d")),
-))]
+#![cfg(feature = "2d")]
 
 use bevy::core::CorePlugin;
 use bevy::prelude::*;
 use bevy::reflect::TypeRegistryArc;
 
-use heron_core::{Body, PhysicMaterial, RotationConstraints};
-use heron_rapier::convert::IntoBevy;
+use heron_core::{Body, RotationConstraints};
 use heron_rapier::rapier::dynamics::{IntegrationParameters, RigidBodySet};
-use heron_rapier::rapier::math::AngVector;
 use heron_rapier::{BodyHandle, RapierPlugin};
 
 fn test_app() -> App {
@@ -26,7 +21,6 @@ fn test_app() -> App {
 }
 
 #[test]
-#[cfg(feature = "2d")]
 fn rotation_is_not_constrained_without_the_component() {
     let mut app = test_app();
 
@@ -48,8 +42,7 @@ fn rotation_is_not_constrained_without_the_component() {
 }
 
 #[test]
-#[cfg(feature = "2d")]
-fn rotation_can_be_locked_on_creation() {
+fn rotation_can_be_locked_at_creation() {
     let mut app = test_app();
 
     let entity = app.world.spawn((
@@ -57,6 +50,34 @@ fn rotation_can_be_locked_on_creation() {
         Body::Sphere { radius: 10.0 },
         RotationConstraints::lock(),
     ));
+
+    app.update();
+
+    let bodies = app.resources.get::<RigidBodySet>().unwrap();
+
+    assert_eq!(
+        bodies
+            .get(app.world.get::<BodyHandle>(entity).unwrap().rigid_body())
+            .unwrap()
+            .effective_world_inv_inertia_sqrt,
+        0.0
+    );
+}
+
+#[test]
+#[ignore]
+fn rotation_can_be_locked_after_creation() {
+    let mut app = test_app();
+
+    let entity = app
+        .world
+        .spawn((GlobalTransform::default(), Body::Sphere { radius: 10.0 }));
+
+    app.update();
+
+    app.world
+        .insert_one(entity, RotationConstraints::lock())
+        .unwrap();
 
     app.update();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,6 +128,7 @@
 //! * How to define the world's [`Gravity`]
 //! * How to define the [`PhysicMaterial`]
 //! * How to listen to [`CollisionEvent`]
+//! * How to define [`RotationConstraints`]
 
 use bevy::app::{AppBuilder, Plugin};
 
@@ -146,7 +147,7 @@ pub mod rapier_plugin {
 pub mod prelude {
     pub use crate::{
         ext::*, stage, AxisAngle, Body, BodyType, CollisionEvent, Gravity, PhysicMaterial,
-        PhysicsPlugin, Velocity,
+        PhysicsPlugin, RotationConstraints, Velocity,
     };
 }
 


### PR DESCRIPTION
Allow to lock rotation around axes.

Resolves #53 


## Remaining tasks
* [x] Provide the following constructors: `lock()`, `allow()`, `allow_around_x_only()`, `allow_around_y_only()` and `allow_around_z_only()`
* [x] Add tests (in mass properties, the invere angular intertia should be 0 if rotation is locked)  
* [x] Update the mass properties if the constraint change after rigid-body creation
