### PR TITLE
feat!: Body::TriMesh implementation

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -56,8 +56,8 @@ pub enum Body {
         positions: Vec<Vec3>,
 
         /// A vector of slices of size 3. each value in the slice is the index of a position in the positions vector that together define a triangle
-        indices: Vec<[u32; 3]>
-    }
+        indices: Vec<[u32; 3]>,
+    },
 }
 
 /// Component that defines the *type* of rigid body.

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -49,6 +49,15 @@ pub enum Body {
         /// In 2d the `z` axis is ignored
         half_extends: Vec3,
     },
+
+    /// A shape made of triangles
+    TriMesh {
+        /// A vector of points that define the shape
+        positions: Vec<Vec3>,
+
+        /// A vector of slices of size 3. each value in the slice is the index of a position in the positions vector that together define a triangle
+        indices: Vec<[u32; 3]>
+    }
 }
 
 /// Component that defines the *type* of rigid body.

--- a/debug/src/dim2.rs
+++ b/debug/src/dim2.rs
@@ -122,7 +122,14 @@ fn base_builder(body: &Body) -> GeometryBuilder {
             });
         }
         Body::TriMesh { positions, indices } => {
-            todo!();
+            let mut path = PathBuilder::new();
+            for triangle in indices {
+                path.move_to(positions[triangle[0]]);
+                path.line_to(positions[triangle[1]]);
+                path.line_to(positions[triangle[2]]);
+            }
+            path.close();
+            builder.add(&path.build());
         }
     };
 

--- a/debug/src/dim2.rs
+++ b/debug/src/dim2.rs
@@ -121,6 +121,9 @@ fn base_builder(body: &Body) -> GeometryBuilder {
                 height: 2.0 * half_extends.y,
             });
         }
+        Body::TriMesh { positions, indices } => {
+            todo!();
+        }
     };
 
     builder

--- a/rapier/src/body.rs
+++ b/rapier/src/body.rs
@@ -242,7 +242,7 @@ fn cuboid_builder(half_extends: Vec3) -> ColliderBuilder {
 #[inline]
 #[cfg(feature = "2d")]
 fn trimesh_builder(vertices: Vec<Vec3>, indices: Vec<[u32; 3]>) -> ColliderBuilder {
-    let vertices: Vec<Vec2> = vertices.iter().map(|v| Vec2::new(v.x, v.y) ).collect();
+    let vertices: Vec<Vec2> = vertices.iter().map(|v| Vec2::new(v.x, v.y)).collect();
 
     ColliderBuilder::trimesh(vertices.into_rapier(), indices)
 }
@@ -333,6 +333,63 @@ mod tests {
 
     #[test]
     fn build_trimesh() {
-        todo!();
+        let positions = vec![
+            //Cube 1
+            Vec3::new(0.0, 0.0, 0.0),
+            Vec3::new(0.0, 0.0, 1.0),
+            Vec3::new(0.0, 1.0, 0.0),
+            Vec3::new(0.0, 1.0, 1.0),
+            Vec3::new(1.0, 0.0, 0.0),
+            Vec3::new(1.0, 0.0, 1.0),
+            Vec3::new(1.0, 1.0, 0.0),
+            Vec3::new(1.0, 1.0, 1.0),
+        ];
+
+        let indices = vec![
+            [0, 1, 2],
+            [1, 3, 2],
+            [1, 5, 3],
+            [5, 7, 3],
+            [5, 4, 7],
+            [4, 6, 7],
+            [4, 0, 6],
+            [0, 2, 6],
+        ];
+
+        let builder_1 = build_collider(
+            Entity::new(0),
+            &Body::TriMesh {
+                positions: positions.clone(),
+                indices: indices.clone(),
+            },
+            BodyType::default(),
+            None,
+        );
+
+        let builder_2 = build_collider(
+            Entity::new(1),
+            &Body::TriMesh {
+                positions: positions
+                    .clone()
+                    .iter()
+                    .map(|p| Vec3::new(p.x + 0.5, p.y, p.z))
+                    .collect(),
+                indices,
+            },
+            BodyType::default(),
+            None,
+        );
+
+        let trimesh_1 = builder_1
+            .shape()
+            .as_trimesh()
+            .expect("Created shape was not a trimesh");
+
+        let trimesh_2 = builder_2
+            .shape()
+            .as_trimesh()
+            .expect("Created shape was not a trimesh");
+
+        //Collision check ??
     }
 }

--- a/rapier/src/body.rs
+++ b/rapier/src/body.rs
@@ -213,7 +213,7 @@ fn build_collider(
             radius,
         } => ColliderBuilder::capsule_y(*half_height, *radius),
         Body::Cuboid { half_extends } => cuboid_builder(*half_extends),
-        Body::TriMesh { positions, indices } => trimesh_builder(positions.clone(), indices.clone())
+        Body::TriMesh { positions, indices } => trimesh_builder(positions.clone(), indices.clone()),
     };
 
     builder = builder
@@ -241,8 +241,10 @@ fn cuboid_builder(half_extends: Vec3) -> ColliderBuilder {
 
 #[inline]
 #[cfg(feature = "2d")]
-fn trimesh_builder(vertices: Vec<Vec2>, indices: Vec<[u32; 3]>) -> ColliderBuilder {
-    todo!();
+fn trimesh_builder(vertices: Vec<Vec3>, indices: Vec<[u32; 3]>) -> ColliderBuilder {
+    let vertices: Vec<Vec2> = vertices.iter().map(|v| Vec2::new(v.x, v.y) ).collect();
+
+    ColliderBuilder::trimesh(vertices.into_rapier(), indices)
 }
 
 #[inline]

--- a/rapier/src/body.rs
+++ b/rapier/src/body.rs
@@ -240,6 +240,12 @@ fn cuboid_builder(half_extends: Vec3) -> ColliderBuilder {
 }
 
 #[inline]
+#[cfg(feature = "2d")]
+fn trimesh_builder(vertices: Vec<Vec2>, indices: Vec<[u32; 3]>) -> ColliderBuilder {
+    todo!();
+}
+
+#[inline]
 #[cfg(feature = "3d")]
 fn trimesh_builder(vertices: Vec<Vec3>, indices: Vec<[u32; 3]>) -> ColliderBuilder {
     ColliderBuilder::trimesh(vertices.into_rapier(), indices)

--- a/rapier/src/body.rs
+++ b/rapier/src/body.rs
@@ -213,6 +213,7 @@ fn build_collider(
             radius,
         } => ColliderBuilder::capsule_y(*half_height, *radius),
         Body::Cuboid { half_extends } => cuboid_builder(*half_extends),
+        Body::TriMesh { positions, indices } => trimesh_builder(positions.clone(), indices.clone())
     };
 
     builder = builder
@@ -236,6 +237,12 @@ fn cuboid_builder(half_extends: Vec3) -> ColliderBuilder {
 #[cfg(feature = "3d")]
 fn cuboid_builder(half_extends: Vec3) -> ColliderBuilder {
     ColliderBuilder::cuboid(half_extends.x, half_extends.y, half_extends.z)
+}
+
+#[inline]
+#[cfg(feature = "3d")]
+fn trimesh_builder(vertices: Vec<Vec3>, indices: Vec<[u32; 3]>) -> ColliderBuilder {
+    ColliderBuilder::trimesh(vertices.into_rapier(), indices)
 }
 
 fn body_status(body_type: BodyType) -> BodyStatus {
@@ -314,5 +321,10 @@ mod tests {
         assert_eq!(capsule.segment.a.z, 0.0);
         #[cfg(feature = "3d")]
         assert_eq!(capsule.segment.b.z, 0.0);
+    }
+
+    #[test]
+    fn build_trimesh() {
+        todo!();
     }
 }

--- a/rapier/src/convert.rs
+++ b/rapier/src/convert.rs
@@ -8,7 +8,7 @@
 use bevy_math::prelude::*;
 
 use heron_core::AxisAngle;
-use rapier::na::Point3;
+use rapier::na::{Point2, Point3};
 
 use crate::nalgebra::{self, Quaternion, UnitComplex, UnitQuaternion, Vector2, Vector3};
 use crate::rapier::math::{Isometry, Translation, Vector};
@@ -118,9 +118,21 @@ impl IntoRapier<Vector3<f32>> for AxisAngle {
     }
 }
 
+impl IntoRapier<Point2<f32>> for Vec2 {
+    fn into_rapier(self) -> Point2<f32> {
+        Point2::<f32>::new(self.x, self.y)
+    }
+}
+
 impl IntoRapier<Point3<f32>> for Vec3 {
     fn into_rapier(self) -> Point3<f32> {
         Point3::<f32>::new(self.x, self.y, self.z)
+    }
+}
+
+impl IntoRapier<Vec<Point2<f32>>> for Vec<Vec2> {
+    fn into_rapier(self) -> Vec<Point2<f32>> {
+        self.iter().map(|v| v.into_rapier()).collect()
     }
 }
 

--- a/rapier/src/convert.rs
+++ b/rapier/src/convert.rs
@@ -8,6 +8,7 @@
 use bevy_math::prelude::*;
 
 use heron_core::AxisAngle;
+use rapier::na::Point3;
 
 use crate::nalgebra::{self, Quaternion, UnitComplex, UnitQuaternion, Vector2, Vector3};
 use crate::rapier::math::{Isometry, Translation, Vector};
@@ -114,6 +115,18 @@ impl IntoRapier<f32> for AxisAngle {
 impl IntoRapier<Vector3<f32>> for AxisAngle {
     fn into_rapier(self) -> Vector3<f32> {
         Vec3::from(self).into_rapier()
+    }
+}
+
+impl IntoRapier<Point3<f32>> for Vec3 {
+    fn into_rapier(self) -> Point3<f32> {
+        Point3::<f32>::new(self.x, self.y, self.z)
+    }
+}
+
+impl IntoRapier<Vec<Point3<f32>>> for Vec<Vec3> {
+    fn into_rapier(self) -> Vec<Point3<f32>> {
+        self.iter().map(|v| v.into_rapier()).collect()
     }
 }
 


### PR DESCRIPTION
Resolves #41

I have made a new pull request for the Body::TriMesh implementation. This one is based off of Herons main branch. The feature works but still has some todo's left inside as I think they need to be discussed. I have compiled a list of those issues that need to be resolved before this can be reviewed & merged.

- [ ] 1. For the 2D feature ColliderBuilder::trimesh() expects the vertices to be of a format Vec<Vec2> instead of Vec<Vec3>. Here one solution would be that we can map the vertices from 3d to 2d by just stripping away the .z component before passing if off to the builder. The other solution that I think would be more appropriate is that we define seperate Body enums for 2d and 3d as there are multiple shapes that don't have a equivalant in more/less dimensions.
- [ ] 2. Implementing a test case for the trimesh. Here the question is how we want to do this. Are gonna store an example mesh and verify all the vertices and indices match up? Do we hardcode a shape in the test?
- [ ] 3. Implementing a debug visualization for the trimeshes. 


