### PR TITLE
Body2

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -140,6 +140,47 @@ pub enum Body {
     },
 }
 
+/// Components that defines a 2d body subject to physics and collision
+///
+/// # Example
+///
+/// ```
+/// # use bevy::prelude::*;
+/// # use heron_core::*;
+/// fn spawn(commands: &mut Commands, mut materials: ResMut<Assets<ColorMaterial>>) {
+///     commands.spawn(todo!("Spawn your sprite/mesh, incl. at least a GlobalTransform"))
+///         .with(Body::Circle { radius: 1.0 });
+/// }
+/// ```
+#[derive(Debug, Clone, Reflect)]
+pub enum Body2 {
+    /// Circle
+    Circle {
+        /// Radius of the circle
+        radius: f32,
+    },
+
+    /// Rectangle
+    Rectangle {
+        /// A vector from its center to a corner
+        half_extends: Vec2,
+    },
+
+    // /// Square
+    // Square {
+    //     /// Distance to a corner of the square
+    //     radius: f32,
+    // },
+    /// Stadium (a 2d capsule)
+    Stadium {
+        /// Distance from the center of the stadium to the center of a half-circle.
+        half_segment: f32,
+
+        /// Radius of the half-circles
+        radius: f32,
+    },
+}
+
 impl Default for Body {
     fn default() -> Self {
         Self::Sphere { radius: 1.0 }

--- a/rapier/src/body.rs
+++ b/rapier/src/body.rs
@@ -89,7 +89,7 @@ pub(crate) fn create<T: BodyColliderBuilder>(
         }
 
         let rigid_body = bodies.insert(builder.build());
-        let mut collider = body.build(entity, body_type, material.cloned().unwrap_or_default());
+        let collider = body.build(entity, body_type, material.cloned().unwrap_or_default());
 
         let collider_handle = colliders.insert(collider, rigid_body, &mut bodies);
         handles.insert(entity, rigid_body);

--- a/rapier/src/body.rs
+++ b/rapier/src/body.rs
@@ -15,89 +15,22 @@ use crate::BodyHandle;
 
 pub(crate) type HandleMap = FnvHashMap<Entity, RigidBodyHandle>;
 
-#[allow(clippy::type_complexity)]
-pub(crate) fn create(
-    commands: &mut Commands,
-    mut bodies: ResMut<'_, RigidBodySet>,
-    mut colliders: ResMut<'_, ColliderSet>,
-    mut handles: ResMut<'_, HandleMap>,
-    query: Query<
-        '_,
-        (
-            Entity,
-            &Body,
-            &GlobalTransform,
-            Option<&BodyType>,
-            Option<&Velocity>,
-            Option<&PhysicMaterial>,
-            Option<&RotationConstraints>,
-        ),
-        Without<BodyHandle>,
-    >,
-) {
-    for (entity, body, transform, body_type, velocity, material, rotation_constraints) in
-        query.iter()
-    {
-        let body_type = body_type.cloned().unwrap_or_default();
+pub trait BodyColliderBuilder: Component {
+    fn collider_builder(&self) -> ColliderBuilder;
 
-        let mut builder = RigidBodyBuilder::new(body_status(body_type))
+    fn build(&self, entity: Entity, body_type: BodyType, material: PhysicMaterial) -> Collider {
+        let mut collider_builder = self.collider_builder();
+        collider_builder = collider_builder
             .user_data(entity.to_bits().into())
-            .position((transform.translation, transform.rotation).into_rapier());
-
-        #[allow(unused_variables)]
-        if let Some(RotationConstraints {
-            allow_x,
-            allow_y,
-            allow_z,
-        }) = rotation_constraints.cloned()
-        {
-            #[cfg(feature = "2d")]
-            if !allow_z {
-                builder = builder.lock_rotations();
-            }
-            #[cfg(feature = "3d")]
-            {
-                builder = builder.restrict_rotations(allow_x, allow_y, allow_z);
-            }
-        }
-
-        if let Some(v) = velocity {
-            #[cfg(feature = "2d")]
-            {
-                builder = builder.linvel(v.linear.x, v.linear.y);
-            }
-            #[cfg(feature = "3d")]
-            {
-                builder = builder.linvel(v.linear.x, v.linear.y, v.linear.z);
-            }
-
-            builder = builder.angvel(v.angular.into_rapier());
-        }
-
-        let rigid_body = bodies.insert(builder.build());
-        let collider = colliders.insert(
-            build_collider(
-                entity,
-                &body,
-                body_type,
-                material.cloned().unwrap_or_default(),
-            ),
-            rigid_body,
-            &mut bodies,
-        );
-        handles.insert(entity, rigid_body);
-        commands.insert_one(
-            entity,
-            BodyHandle {
-                rigid_body,
-                collider,
-            },
-        );
+            .sensor(matches!(body_type, BodyType::Sensor))
+            .restitution(material.restitution)
+            .density(material.density);
+        collider_builder.build()
     }
 }
 
 #[allow(clippy::type_complexity)]
-pub(crate) fn create2(
+pub(crate) fn create<T: BodyColliderBuilder>(
     commands: &mut Commands,
     mut bodies: ResMut<'_, RigidBodySet>,
     mut colliders: ResMut<'_, ColliderSet>,
@@ -106,7 +39,7 @@ pub(crate) fn create2(
         '_,
         (
             Entity,
-            &Body2,
+            &T,
             &GlobalTransform,
             Option<&BodyType>,
             Option<&Velocity>,
@@ -156,22 +89,15 @@ pub(crate) fn create2(
         }
 
         let rigid_body = bodies.insert(builder.build());
-        let collider = colliders.insert(
-            build_collider2(
-                entity,
-                &body,
-                body_type,
-                material.cloned().unwrap_or_default(),
-            ),
-            rigid_body,
-            &mut bodies,
-        );
+        let mut collider = body.build(entity, body_type, material.cloned().unwrap_or_default());
+
+        let collider_handle = colliders.insert(collider, rigid_body, &mut bodies);
         handles.insert(entity, rigid_body);
         commands.insert_one(
             entity,
             BodyHandle {
                 rigid_body,
-                collider,
+                collider: collider_handle,
             },
         );
     }
@@ -309,53 +235,31 @@ pub(crate) fn remove(
     }
 }
 
-fn build_collider(
-    entity: Entity,
-    body: &Body,
-    body_type: BodyType,
-    material: PhysicMaterial,
-) -> Collider {
-    let mut builder = match body {
-        Body::Sphere { radius } => ColliderBuilder::ball(*radius),
-        Body::Capsule {
-            half_segment: half_height,
-            radius,
-        } => ColliderBuilder::capsule_y(*half_height, *radius),
-        Body::Cuboid { half_extends } => cuboid_builder(*half_extends),
-        Body::ConvexHull { points } => convex_hull_builder(points.as_slice()),
-    };
-
-    builder = builder
-        .user_data(entity.to_bits().into())
-        .sensor(matches!(body_type, BodyType::Sensor))
-        .restitution(material.restitution)
-        .density(material.density);
-
-    builder.build()
+impl BodyColliderBuilder for Body {
+    fn collider_builder(&self) -> ColliderBuilder {
+        match self {
+            Body::Sphere { radius } => ColliderBuilder::ball(*radius),
+            Body::Capsule {
+                half_segment: half_height,
+                radius,
+            } => ColliderBuilder::capsule_y(*half_height, *radius),
+            Body::Cuboid { half_extends } => cuboid_builder(*half_extends),
+            Body::ConvexHull { points } => convex_hull_builder(points.as_slice()),
+        }
+    }
 }
 
-fn build_collider2(
-    entity: Entity,
-    body: &Body2,
-    body_type: BodyType,
-    material: PhysicMaterial,
-) -> Collider {
-    let mut builder = match body {
-        Body2::Circle { radius } => ColliderBuilder::ball(*radius),
-        Body2::Stadium {
-            half_segment: half_height,
-            radius,
-        } => ColliderBuilder::capsule_y(*half_height, *radius),
-        Body2::Rectangle { half_extends } => cuboid_builder(half_extends.extend(0.0)),
-    };
-
-    builder = builder
-        .user_data(entity.to_bits().into())
-        .sensor(matches!(body_type, BodyType::Sensor))
-        .restitution(material.restitution)
-        .density(material.density);
-
-    builder.build()
+impl BodyColliderBuilder for Body2 {
+    fn collider_builder(&self) -> ColliderBuilder {
+        match self {
+            Body2::Circle { radius } => ColliderBuilder::ball(*radius),
+            Body2::Stadium {
+                half_segment: half_height,
+                radius,
+            } => ColliderBuilder::capsule_y(*half_height, *radius),
+            Body2::Rectangle { half_extends } => cuboid_builder(half_extends.extend(0.0)),
+        }
+    }
 }
 
 #[inline]
@@ -392,13 +296,13 @@ mod tests {
 
     #[test]
     fn build_sphere() {
-        let builder = build_collider(
+        let collider = Body::Sphere { radius: 4.2 }.build(
             Entity::new(0),
-            &Body::Sphere { radius: 4.2 },
             BodyType::default(),
             Default::default(),
         );
-        let ball = builder
+
+        let ball = collider
             .shape()
             .as_ball()
             .expect("Created shape was not a ball");
@@ -407,15 +311,12 @@ mod tests {
 
     #[test]
     fn build_cuboid() {
-        let builder = build_collider(
-            Entity::new(0),
-            &Body::Cuboid {
-                half_extends: Vec3::new(1.0, 2.0, 3.0),
-            },
-            BodyType::default(),
-            Default::default(),
-        );
-        let cuboid = builder
+        let collider = Body::Cuboid {
+            half_extends: Vec3::new(1.0, 2.0, 3.0),
+        }
+        .build(Entity::new(0), BodyType::default(), Default::default());
+
+        let cuboid = collider
             .shape()
             .as_cuboid()
             .expect("Created shape was not a cuboid");
@@ -429,16 +330,13 @@ mod tests {
 
     #[test]
     fn build_capsule() {
-        let builder = build_collider(
-            Entity::new(0),
-            &Body::Capsule {
-                half_segment: 10.0,
-                radius: 5.0,
-            },
-            BodyType::default(),
-            Default::default(),
-        );
-        let capsule = builder
+        let collider = Body::Capsule {
+            half_segment: 10.0,
+            radius: 5.0,
+        }
+        .build(Entity::new(0), BodyType::default(), Default::default());
+
+        let capsule = collider
             .shape()
             .as_capsule()
             .expect("Created shape was not a capsule");

--- a/rapier/src/lib.rs
+++ b/rapier/src/lib.rs
@@ -16,7 +16,7 @@ pub extern crate rapier3d as rapier;
 use bevy::app::{AppBuilder, Plugin};
 use bevy::ecs::{IntoSystem, Schedule, SystemStage};
 
-use heron_core::CollisionEvent;
+use heron_core::{Body, Body2, CollisionEvent};
 
 use crate::body::HandleMap;
 use crate::rapier::dynamics::{IntegrationParameters, JointSet, RigidBodyHandle, RigidBodySet};
@@ -132,8 +132,8 @@ impl Plugin for RapierPlugin {
                         .with_system(velocity::update_rapier_velocity.system())
                         .with_system(body::update_rapier_status.system())
                         .with_system(acceleration::update_rapier_force_and_torque.system())
-                        .with_system(body::create.system())
-                        .with_system(body::create2.system()),
+                        .with_system(body::create::<Body>.system())
+                        .with_system(body::create::<Body2>.system()),
                 )
                 .add_stage(
                     "heron-step",

--- a/rapier/src/lib.rs
+++ b/rapier/src/lib.rs
@@ -132,7 +132,8 @@ impl Plugin for RapierPlugin {
                         .with_system(velocity::update_rapier_velocity.system())
                         .with_system(body::update_rapier_status.system())
                         .with_system(acceleration::update_rapier_force_and_torque.system())
-                        .with_system(body::create.system()),
+                        .with_system(body::create.system())
+                        .with_system(body::create2.system()),
                 )
                 .add_stage(
                     "heron-step",


### PR DESCRIPTION
This is a draft implementation of #72. Not all convenience shapes are implemented, but I wanted to do a proof of concept.

I've created a `BodyColliderBuilder` trait that is now implemented by both the `Body` component as well as by `Body2`. This allows us to create bodies for Body2 too.

While I'm not displeased by the structure of the code, the debug renderer would need to be adjusted as well.

Since the debug renderer is supposed to work for 2d, we could assume users create Body2 instances and dedicate the debug renderer to this. Alternatively we'd need to support both Body and Body2 in the debug renderer, which would necessitate another trait.

But perhaps we could shift the traits around. We introduce a trait, `BodyFactory` with a `create` method that returns Body. Body would implement this by returning self, but `Body2` would return `Body` instead. This way any user code would deal with Body only. 

I don't know what's preferable - should user code that's in 2d only deal with Body or would it actually be nicer if they only have to deal with Body2? Is user code expected to deal with Body a lot anyway, outside of the debug renderer?

