### PR TITLE
fix: Frame delay after a spawn/update of the entity transform

### DIFF
--- a/rapier/src/body.rs
+++ b/rapier/src/body.rs
@@ -102,7 +102,7 @@ pub(crate) fn create(
 }
 
 #[allow(clippy::type_complexity)]
-pub(crate) fn remove_bodies(
+pub(crate) fn remove_invalid_bodies(
     mut commands: Commands<'_>,
     mut bodies: ResMut<'_, RigidBodySet>,
     mut colliders: ResMut<'_, ColliderSet>,

--- a/rapier/src/lib.rs
+++ b/rapier/src/lib.rs
@@ -128,8 +128,9 @@ impl Plugin for RapierPlugin {
                 .add_stage(
                     "heron-remove-bodies",
                     SystemStage::single_threaded()
-                        .with_system(body::remove_invalid_bodies.system())
-                        .with_system(body::remove.system()),
+                        .with_system(body::remove.system())
+                        .with_system(body::remove_invalids_after_component_changed.system())
+                        .with_system(body::remove_invalids_after_component_removed.system()),
                 )
                 .add_stage(
                     "heron-update-rapier-world",


### PR DESCRIPTION
Since bevy 0.5 the order of execution of systems are no longer guaranteed in single-threaded system stages.

This has led to a tiny issue in heron, that may update the rapier world before the transform propagation system has run. The rapier world will eventually be correctly updated on the next frame. But that's one frame later than it should.

This PR fixes this frame-delay by ensuring the transform propagation always run before updating the rapier world. It also use the opportunity to simplify (a tiny bit) the internal heron stages/system organization.