### PR TITLE
Implement a HeightField collision shape

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -148,6 +148,20 @@ pub enum CollisionShape {
         /// A vector of points describing the convex hull
         points: Vec<Vec3>,
     },
+
+    /// A shape defined by the height of points.
+    ///
+    /// This shape is usefull for floors with relief.
+    HeightField {
+        /// The distance between two points of the field
+        scale: f32,
+
+        /// The height of each point.
+        ///
+        /// In 2D, the outer `Vec` should contain only one
+        /// inner `Vec`, any other element will be ignored.
+        heights: Vec<Vec<f32>>,
+    },
 }
 
 impl Default for CollisionShape {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -153,8 +153,10 @@ pub enum CollisionShape {
     ///
     /// This shape is usefull for floors with relief.
     HeightField {
-        /// The distance between two points of the field
-        scale: f32,
+        /// The dimensions of the field.
+        ///
+        /// In 2D, only the first element is taken into account.
+        size: Vec2,
 
         /// The height of each point.
         ///

--- a/debug/src/dim2.rs
+++ b/debug/src/dim2.rs
@@ -149,14 +149,28 @@ fn base_builder(body: &CollisionShape, shape: &dyn Shape) -> GeometryBuilder {
             }
         }
         CollisionShape::HeightField { scale, heights } => {
-            if let Some(points) = heights.get(0) {
+            if let Some(heights) = heights.get(0) {
+                let mut points: Vec<Vec2> = Vec::with_capacity(heights.len() + 2);
+                let mut min_y = f32::MAX;
+
+                heights
+                    .iter()
+                    .enumerate()
+                    .map(|(i, p)| Vec2::new((i as f32) * scale, *p))
+                    .for_each(|p| {
+                        if p.y < min_y {
+                            min_y = p.y;
+                        }
+                        points.push(p);
+                    });
+
+                #[allow(clippy::cast_precision_loss)]
+                points.push(Vec2::new(heights.len() as f32 * scale, min_y));
+                points.push(Vec2::new(0.0, min_y));
+
                 builder.add(&shapes::Polygon {
-                    points: points
-                        .iter()
-                        .enumerate()
-                        .map(|(i, p)| Vec2::new((i as f32) * scale, *p))
-                        .collect(),
-                    closed: false,
+                    points,
+                    closed: true,
                 });
             }
         }

--- a/debug/src/dim2.rs
+++ b/debug/src/dim2.rs
@@ -148,6 +148,18 @@ fn base_builder(body: &CollisionShape, shape: &dyn Shape) -> GeometryBuilder {
                 });
             }
         }
+        CollisionShape::HeightField { scale, heights } => {
+            if let Some(points) = heights.get(0) {
+                builder.add(&shapes::Polygon {
+                    points: points
+                        .iter()
+                        .enumerate()
+                        .map(|(i, p)| Vec2::new((i as f32) * scale, *p))
+                        .collect(),
+                    closed: false,
+                });
+            }
+        }
     };
 
     builder

--- a/debug/src/dim2.rs
+++ b/debug/src/dim2.rs
@@ -148,7 +148,7 @@ fn base_builder(body: &CollisionShape, shape: &dyn Shape) -> GeometryBuilder {
                 });
             }
         }
-        CollisionShape::HeightField { scale, heights } => {
+        CollisionShape::HeightField { size, heights } => {
             if let Some(heights) = heights.get(0) {
                 let mut points: Vec<Vec2> = Vec::with_capacity(heights.len() + 2);
                 let mut min_y = f32::MAX;
@@ -156,7 +156,7 @@ fn base_builder(body: &CollisionShape, shape: &dyn Shape) -> GeometryBuilder {
                 heights
                     .iter()
                     .enumerate()
-                    .map(|(i, p)| Vec2::new((i as f32) * scale, *p))
+                    .map(|(i, p)| Vec2::new(i as f32, *p))
                     .for_each(|p| {
                         if p.y < min_y {
                             min_y = p.y;
@@ -165,7 +165,7 @@ fn base_builder(body: &CollisionShape, shape: &dyn Shape) -> GeometryBuilder {
                     });
 
                 #[allow(clippy::cast_precision_loss)]
-                points.push(Vec2::new(heights.len() as f32 * scale, min_y));
+                points.push(Vec2::new(size.x, min_y));
                 points.push(Vec2::new(0.0, min_y));
 
                 builder.add(&shapes::Polygon {

--- a/debug/src/dim2.rs
+++ b/debug/src/dim2.rs
@@ -159,11 +159,13 @@ fn base_builder(body: &CollisionShape, shape: &dyn Shape) -> GeometryBuilder {
             if let Some(heights) = heights.get(0) {
                 let mut points: Vec<Vec2> = Vec::with_capacity(heights.len() + 2);
                 let mut min_y = f32::MAX;
+                let half_size = size.x * 0.5;
+                let len = (heights.len() - 1) as f32;
 
                 heights
                     .iter()
                     .enumerate()
-                    .map(|(i, p)| Vec2::new(i as f32, *p))
+                    .map(|(i, p)| Vec2::new((i as f32) * size.x / len - half_size, *p))
                     .for_each(|p| {
                         if p.y < min_y {
                             min_y = p.y;
@@ -171,9 +173,8 @@ fn base_builder(body: &CollisionShape, shape: &dyn Shape) -> GeometryBuilder {
                         points.push(p);
                     });
 
-                #[allow(clippy::cast_precision_loss)]
-                points.push(Vec2::new(size.x, min_y));
-                points.push(Vec2::new(0.0, min_y));
+                points.push(Vec2::new(half_size, min_y));
+                points.push(Vec2::new(-half_size, min_y));
 
                 builder.add(&shapes::Polygon {
                     points,

--- a/examples/debug.rs
+++ b/examples/debug.rs
@@ -64,8 +64,8 @@ fn spawn(mut commands: Commands) {
             GlobalTransform::default(),
         ))
         .insert(CollisionShape::HeightField {
-            scale: 20.0,
-            heights: vec![vec![0.0, 10.0, 30.0, 20.0, 0.0]],
+            scale: 50.0,
+            heights: vec![vec![50.0, 0.0, 10.0, 30.0, 20.0, 0.0, 20.0]],
         })
         .insert(RigidBody::Static);
 }

--- a/examples/debug.rs
+++ b/examples/debug.rs
@@ -60,11 +60,11 @@ fn spawn(mut commands: Commands) {
     // Height field
     commands
         .spawn_bundle((
-            Transform::from_translation(Vec3::Y * 200.0),
+            Transform::from_translation(Vec3::Y * -200.0),
             GlobalTransform::default(),
         ))
         .insert(CollisionShape::HeightField {
-            size: Vec2::new(6.0, 0.0),
+            size: Vec2::new(700.0, 0.0),
             heights: vec![vec![50.0, 0.0, 10.0, 30.0, 20.0, 0.0, 20.0]],
         })
         .insert(RigidBody::Static);

--- a/examples/debug.rs
+++ b/examples/debug.rs
@@ -64,7 +64,7 @@ fn spawn(mut commands: Commands) {
             GlobalTransform::default(),
         ))
         .insert(CollisionShape::HeightField {
-            scale: 50.0,
+            size: Vec2::new(6.0, 0.0),
             heights: vec![vec![50.0, 0.0, 10.0, 30.0, 20.0, 0.0, 20.0]],
         })
         .insert(RigidBody::Static);

--- a/examples/debug.rs
+++ b/examples/debug.rs
@@ -56,4 +56,16 @@ fn spawn(mut commands: Commands) {
             ],
         })
         .insert(RigidBody::Static);
+
+    // Height field
+    commands
+        .spawn_bundle((
+            Transform::from_translation(Vec3::Y * 200.0),
+            GlobalTransform::default(),
+        ))
+        .insert(CollisionShape::HeightField {
+            scale: 20.0,
+            heights: vec![vec![0.0, 10.0, 30.0, 20.0, 0.0]],
+        })
+        .insert(RigidBody::Static);
 }

--- a/rapier/src/shape.rs
+++ b/rapier/src/shape.rs
@@ -258,11 +258,7 @@ fn heightfield_builder(size: Vec2, heights: &[Vec<f32>]) -> ColliderBuilder {
     let ncols = heights.get(0).map(Vec::len).unwrap_or_default();
     ColliderBuilder::heightfield(
         crate::rapier::na::DMatrix::from_iterator(nrows, ncols, heights.iter().flatten().cloned()),
-        crate::rapier::na::Vector3::new(
-            size.x,
-            1.0,
-            size.y,
-        ),
+        crate::rapier::na::Vector3::new(size.x, 1.0, size.y),
     )
 }
 
@@ -337,7 +333,8 @@ mod tests {
             size: Vec2::new(2.0, 1.0),
             heights: vec![vec![1.0, 2.0, 3.0], vec![4.0, 5.0, 6.0]],
         }
-        .build(Entity::new(0), RigidBody::default(), None, None, None);
+        .collider_builder()
+        .build();
 
         let field = collider
             .shape()

--- a/rapier/src/shape.rs
+++ b/rapier/src/shape.rs
@@ -200,8 +200,9 @@ fn convex_hull_builder(points: &[Vec3]) -> ColliderBuilder {
 
 #[inline]
 #[cfg(feature = "2d")]
+#[allow(clippy::cast_precision_loss)]
 fn heightfield_builder(scale: f32, heights: &[Vec<f32>]) -> ColliderBuilder {
-    let len = heights.get(0).map(|x| x.len()).unwrap_or_default();
+    let len = heights.get(0).map(Vec::len).unwrap_or_default();
     ColliderBuilder::heightfield(
         crate::rapier::na::DVector::from_iterator(len, heights.iter().flatten().take(len).cloned()),
         crate::rapier::na::Vector2::new((len as f32) * scale - scale, 1.0),
@@ -210,9 +211,10 @@ fn heightfield_builder(scale: f32, heights: &[Vec<f32>]) -> ColliderBuilder {
 
 #[inline]
 #[cfg(feature = "3d")]
+#[allow(clippy::cast_precision_loss)]
 fn heightfield_builder(scale: f32, heights: &[Vec<f32>]) -> ColliderBuilder {
     let nrows = heights.len();
-    let ncols = heights.get(0).map(|x| x.len()).unwrap_or_default();
+    let ncols = heights.get(0).map(Vec::len).unwrap_or_default();
     ColliderBuilder::heightfield(
         crate::rapier::na::DMatrix::from_iterator(nrows, ncols, heights.iter().flatten().cloned()),
         crate::rapier::na::Vector3::new(
@@ -296,7 +298,7 @@ mod tests {
             scale: 3.0,
             heights: vec![vec![1.0, 2.0, 3.0], vec![4.0, 5.0, 6.0]],
         }
-        .build(Entity::new(0), RigidBody::default(), None, None);
+        .build(Entity::new(0), RigidBody::default(), None, None, None);
 
         let field = collider
             .shape()


### PR DESCRIPTION
Resolves #62 

Some notes:

- I went with a `Vec<Vec<f32>>` to define the heights, both in 2D and 3D (and only take the first sub-vec in account in 2D). I couldn't get `#[cfg(features)]` to work as I wanted
- I'm not sure about the debug implementation, because I don't know much about lyon. I'll probably add a heightfield to the `debug` example to see if it does what I expect.
- The scale that rapier expects is actually more the dimensions of the field, so I had to do a little conversion.
- Also, it looks like rapier/parry always centers the heightfield. Is there anything I need to do to update the transform of a collision shape in rapier when it is updated in bevy?