### PR TITLE
feat!: More data in collision events

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,3 +49,7 @@ required-features = ["2d", "debug"]
 [[example]]
 name = "layers"
 required-features = ["2d"]
+
+[[example]]
+name = "events"
+required-features = ["2d"]

--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -65,6 +65,13 @@ impl CollisionEvent {
             CollisionEvent::Stopped(d1, d2) => (d1.rigid_body_entity, d2.rigid_body_entity),
         }
     }
+
+    pub fn collision_layers(&self) -> (CollisionLayers, CollisionLayers) {
+        match self {
+            CollisionEvent::Started(d1, d2) => (d1.collision_layers, d2.collision_layers),
+            CollisionEvent::Stopped(d1, d2) => (d1.collision_layers, d2.collision_layers),
+        }
+    }
 }
 
 impl CollisionData {

--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -1,5 +1,7 @@
 use bevy::ecs::entity::Entity;
 
+use crate::CollisionLayers;
+
 /// An event fired when the collision state between two entities changed
 ///
 /// # Example
@@ -16,11 +18,77 @@ use bevy::ecs::entity::Entity;
 ///     }
 /// }
 /// ```
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum CollisionEvent {
     /// The two entities started to collide
-    Started(Entity, Entity),
+    Started(CollisionData, CollisionData),
 
     /// The two entities no longer collide
-    Stopped(Entity, Entity),
+    Stopped(CollisionData, CollisionData),
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct CollisionData {
+    rigid_body_entity: Entity,
+    collision_shape_entity: Entity,
+    collision_layers: CollisionLayers,
+}
+
+impl From<CollisionEvent> for (CollisionData, CollisionData) {
+    fn from(event: CollisionEvent) -> Self {
+        event.data()
+    }
+}
+
+impl CollisionEvent {
+    pub fn data(self) -> (CollisionData, CollisionData) {
+        match self {
+            CollisionEvent::Started(d1, d2) => (d1, d2),
+            CollisionEvent::Stopped(d1, d2) => (d1, d2),
+        }
+    }
+
+    pub fn collision_shape_entities(&self) -> (Entity, Entity) {
+        match self {
+            CollisionEvent::Started(d1, d2) => {
+                (d1.collision_shape_entity, d2.collision_shape_entity)
+            }
+            CollisionEvent::Stopped(d1, d2) => {
+                (d1.collision_shape_entity, d2.collision_shape_entity)
+            }
+        }
+    }
+
+    pub fn rigid_body_entities(&self) -> (Entity, Entity) {
+        match self {
+            CollisionEvent::Started(d1, d2) => (d1.rigid_body_entity, d2.rigid_body_entity),
+            CollisionEvent::Stopped(d1, d2) => (d1.rigid_body_entity, d2.rigid_body_entity),
+        }
+    }
+}
+
+impl CollisionData {
+    pub fn new(
+        rigid_body_entity: Entity,
+        collision_shape_entity: Entity,
+        collision_layers: CollisionLayers,
+    ) -> Self {
+        Self {
+            rigid_body_entity,
+            collision_shape_entity,
+            collision_layers,
+        }
+    }
+
+    pub fn rigid_body_entity(&self) -> Entity {
+        self.rigid_body_entity
+    }
+
+    pub fn collision_shape_entity(&self) -> Entity {
+        self.collision_shape_entity
+    }
+
+    pub fn collision_layers(&self) -> CollisionLayers {
+        self.collision_layers
+    }
 }

--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -47,53 +47,58 @@ impl From<CollisionEvent> for (CollisionData, CollisionData) {
 
 impl CollisionEvent {
     /// Returns true if the event represent the "start" of a collision
+    #[must_use]
     pub fn is_started(&self) -> bool {
         matches!(self, CollisionEvent::Started(_, _))
     }
 
     /// Returns true if the event represent the "end" of a collision
+    #[must_use]
     pub fn is_stopped(&self) -> bool {
         matches!(self, CollisionEvent::Stopped(_, _))
     }
 
     /// Returns the data for the two entities that collided
+    #[must_use]
     pub fn data(self) -> (CollisionData, CollisionData) {
         match self {
-            CollisionEvent::Started(d1, d2) => (d1, d2),
-            CollisionEvent::Stopped(d1, d2) => (d1, d2),
+            CollisionEvent::Started(d1, d2) | CollisionEvent::Stopped(d1, d2) => (d1, d2),
         }
     }
 
     /// Returns the entities containing the [`CollisionShape`](crate::RigidBody) involved in the collision
+    #[must_use]
     pub fn collision_shape_entities(&self) -> (Entity, Entity) {
         match self {
-            CollisionEvent::Started(d1, d2) => {
-                (d1.collision_shape_entity, d2.collision_shape_entity)
-            }
-            CollisionEvent::Stopped(d1, d2) => {
+            CollisionEvent::Started(d1, d2) | CollisionEvent::Stopped(d1, d2) => {
                 (d1.collision_shape_entity, d2.collision_shape_entity)
             }
         }
     }
 
     /// Returns the entities containing the [`RigidBody`](crate::RigidBody) involved in the collision
+    #[must_use]
     pub fn rigid_body_entities(&self) -> (Entity, Entity) {
         match self {
-            CollisionEvent::Started(d1, d2) => (d1.rigid_body_entity, d2.rigid_body_entity),
-            CollisionEvent::Stopped(d1, d2) => (d1.rigid_body_entity, d2.rigid_body_entity),
+            CollisionEvent::Started(d1, d2) | CollisionEvent::Stopped(d1, d2) => {
+                (d1.rigid_body_entity, d2.rigid_body_entity)
+            }
         }
     }
 
     /// Returns the two [`CollisionLayers`] involved in the collision
+    #[must_use]
     pub fn collision_layers(&self) -> (CollisionLayers, CollisionLayers) {
         match self {
-            CollisionEvent::Started(d1, d2) => (d1.collision_layers, d2.collision_layers),
-            CollisionEvent::Stopped(d1, d2) => (d1.collision_layers, d2.collision_layers),
+            CollisionEvent::Started(d1, d2) | CollisionEvent::Stopped(d1, d2) => {
+                (d1.collision_layers, d2.collision_layers)
+            }
         }
     }
 }
 
 impl CollisionData {
+    #[must_use]
     #[allow(missing_docs)]
     pub fn new(
         rigid_body_entity: Entity,
@@ -108,16 +113,19 @@ impl CollisionData {
     }
 
     /// Returns the entity containing the [`RigidBody`](crate::RigidBody)
+    #[must_use]
     pub fn rigid_body_entity(&self) -> Entity {
         self.rigid_body_entity
     }
 
     /// Returns the entity containing the [`CollisionShape`](crate::CollisionShape)
+    #[must_use]
     pub fn collision_shape_entity(&self) -> Entity {
         self.collision_shape_entity
     }
 
     /// Returns the [`CollisionLayers`] of the collision shape entity
+    #[must_use]
     pub fn collision_layers(&self) -> CollisionLayers {
         self.collision_layers
     }

--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -1,0 +1,26 @@
+use bevy::ecs::entity::Entity;
+
+/// An event fired when the collision state between two entities changed
+///
+/// # Example
+///
+/// ```
+/// # use bevy::prelude::*;
+/// # use heron_core::*;
+/// fn detect_collisions(mut events: EventReader<CollisionEvent>) {
+///     for event in events.iter() {
+///         match event {
+///             CollisionEvent::Started(entity1, entity2) => println!("Entity {:?} and {:?} started to collide", entity1, entity2),
+///             CollisionEvent::Stopped(entity1, entity2) => println!("Entity {:?} and {:?} stopped to collide", entity1, entity2),
+///         }
+///     }
+/// }
+/// ```
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum CollisionEvent {
+    /// The two entities started to collide
+    Started(Entity, Entity),
+
+    /// The two entities no longer collide
+    Stopped(Entity, Entity),
+}

--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -12,8 +12,12 @@ use crate::CollisionLayers;
 /// fn detect_collisions(mut events: EventReader<CollisionEvent>) {
 ///     for event in events.iter() {
 ///         match event {
-///             CollisionEvent::Started(entity1, entity2) => println!("Entity {:?} and {:?} started to collide", entity1, entity2),
-///             CollisionEvent::Stopped(entity1, entity2) => println!("Entity {:?} and {:?} stopped to collide", entity1, entity2),
+///             CollisionEvent::Started(data1, data2) => {
+///                 println!("Entity {:?} and {:?} started to collide", data1.rigid_body_entity(), data2.rigid_body_entity())
+///             }
+///             CollisionEvent::Stopped(data1, data2) => {
+///                 println!("Entity {:?} and {:?} stopped to collide", data1.rigid_body_entity(), data2.rigid_body_entity())
+///             }
 ///         }
 ///     }
 /// }
@@ -27,6 +31,7 @@ pub enum CollisionEvent {
     Stopped(CollisionData, CollisionData),
 }
 
+/// Collision data concerning one of the two entity that collided
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct CollisionData {
     rigid_body_entity: Entity,
@@ -41,6 +46,17 @@ impl From<CollisionEvent> for (CollisionData, CollisionData) {
 }
 
 impl CollisionEvent {
+    /// Returns true if the event represent the "start" of a collision
+    pub fn is_started(&self) -> bool {
+        matches!(self, CollisionEvent::Started(_, _))
+    }
+
+    /// Returns true if the event represent the "end" of a collision
+    pub fn is_stopped(&self) -> bool {
+        matches!(self, CollisionEvent::Stopped(_, _))
+    }
+
+    /// Returns the data for the two entities that collided
     pub fn data(self) -> (CollisionData, CollisionData) {
         match self {
             CollisionEvent::Started(d1, d2) => (d1, d2),
@@ -48,6 +64,7 @@ impl CollisionEvent {
         }
     }
 
+    /// Returns the entities containing the [`CollisionShape`](crate::RigidBody) involved in the collision
     pub fn collision_shape_entities(&self) -> (Entity, Entity) {
         match self {
             CollisionEvent::Started(d1, d2) => {
@@ -59,6 +76,7 @@ impl CollisionEvent {
         }
     }
 
+    /// Returns the entities containing the [`RigidBody`](crate::RigidBody) involved in the collision
     pub fn rigid_body_entities(&self) -> (Entity, Entity) {
         match self {
             CollisionEvent::Started(d1, d2) => (d1.rigid_body_entity, d2.rigid_body_entity),
@@ -66,6 +84,7 @@ impl CollisionEvent {
         }
     }
 
+    /// Returns the two [`CollisionLayers`] involved in the collision
     pub fn collision_layers(&self) -> (CollisionLayers, CollisionLayers) {
         match self {
             CollisionEvent::Started(d1, d2) => (d1.collision_layers, d2.collision_layers),
@@ -75,6 +94,7 @@ impl CollisionEvent {
 }
 
 impl CollisionData {
+    #[allow(missing_docs)]
     pub fn new(
         rigid_body_entity: Entity,
         collision_shape_entity: Entity,
@@ -87,14 +107,17 @@ impl CollisionData {
         }
     }
 
+    /// Returns the entity containing the [`RigidBody`](crate::RigidBody)
     pub fn rigid_body_entity(&self) -> Entity {
         self.rigid_body_entity
     }
 
+    /// Returns the entity containing the [`CollisionShape`](crate::CollisionShape)
     pub fn collision_shape_entity(&self) -> Entity {
         self.collision_shape_entity
     }
 
+    /// Returns the [`CollisionLayers`] of the collision shape entity
     pub fn collision_layers(&self) -> CollisionLayers {
         self.collision_layers
     }

--- a/core/src/layers.rs
+++ b/core/src/layers.rs
@@ -86,6 +86,7 @@ impl CollisionLayers {
     /// Create a new collision layers configuration with a single group and mask.
     ///
     /// You may add more groups and mask with `with_group` and `with_mask`.
+    #[must_use]
     pub fn new<L: PhysicsLayer>(group: L, mask: L) -> Self {
         Self::from_bits(group.to_bits(), mask.to_bits())
     }
@@ -106,6 +107,7 @@ impl CollisionLayers {
         Self::from_bits(0, 0)
     }
 
+    #[must_use]
     #[allow(missing_docs)]
     pub fn from_bits(groups: u16, masks: u16) -> Self {
         Self { groups, masks }

--- a/core/src/layers.rs
+++ b/core/src/layers.rs
@@ -87,10 +87,7 @@ impl CollisionLayers {
     ///
     /// You may add more groups and mask with `with_group` and `with_mask`.
     pub fn new<L: PhysicsLayer>(group: L, mask: L) -> Self {
-        Self {
-            groups: group.to_bits(),
-            masks: mask.to_bits(),
-        }
+        Self::from_bits(group.to_bits(), mask.to_bits())
     }
 
     /// Contains all layers
@@ -98,10 +95,7 @@ impl CollisionLayers {
     /// The entity,will interacts with everything (except the entities that interact with nothing)
     #[must_use]
     pub fn all<L: PhysicsLayer>() -> Self {
-        Self {
-            groups: L::all_bits(),
-            masks: L::all_bits(),
-        }
+        Self::from_bits(L::all_bits(), L::all_bits())
     }
 
     /// Contains no layer
@@ -109,10 +103,12 @@ impl CollisionLayers {
     /// The entity, will not interact with anything
     #[must_use]
     pub fn none() -> Self {
-        Self {
-            groups: 0,
-            masks: 0,
-        }
+        Self::from_bits(0, 0)
+    }
+
+    #[allow(missing_docs)]
+    pub fn from_bits(groups: u16, masks: u16) -> Self {
+        Self { groups, masks }
     }
 
     /// Returns true if the entity would interact with an entity containing the `other` [`CollisionLayers]`

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -8,6 +8,7 @@ use bevy::core::FixedTimestep;
 use bevy::prelude::*;
 
 pub use constraints::RotationConstraints;
+pub use events::CollisionEvent;
 pub use ext::*;
 pub use gravity::Gravity;
 pub use layers::{CollisionLayers, PhysicsLayer};
@@ -15,6 +16,7 @@ pub use physics_time::PhysicsTime;
 pub use velocity::{Acceleration, AxisAngle, Velocity};
 
 mod constraints;
+mod events;
 pub mod ext;
 mod gravity;
 mod layers;
@@ -223,31 +225,6 @@ impl RigidBody {
             RigidBody::Static | RigidBody::Sensor => false,
         }
     }
-}
-
-/// An event fired when the collision state between two entities changed
-///
-/// # Example
-///
-/// ```
-/// # use bevy::prelude::*;
-/// # use heron_core::*;
-/// fn detect_collisions(mut events: EventReader<CollisionEvent>) {
-///     for event in events.iter() {
-///         match event {
-///             CollisionEvent::Started(entity1, entity2) => println!("Entity {:?} and {:?} started to collide", entity1, entity2),
-///             CollisionEvent::Stopped(entity1, entity2) => println!("Entity {:?} and {:?} stopped to collide", entity1, entity2),
-///         }
-///     }
-/// }
-/// ```
-#[derive(Debug, Copy, Clone, PartialEq)]
-pub enum CollisionEvent {
-    /// The two entities started to collide
-    Started(Entity, Entity),
-
-    /// The two entities no longer collide
-    Stopped(Entity, Entity),
 }
 
 /// Component that defines the physics properties of the rigid body

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -8,7 +8,7 @@ use bevy::core::FixedTimestep;
 use bevy::prelude::*;
 
 pub use constraints::RotationConstraints;
-pub use events::CollisionEvent;
+pub use events::{CollisionData, CollisionEvent};
 pub use ext::*;
 pub use gravity::Gravity;
 pub use layers::{CollisionLayers, PhysicsLayer};

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -67,11 +67,11 @@ fn spawn(mut commands: Commands, mut materials: ResMut<Assets<ColorMaterial>>) {
 fn log_collisions(mut events: EventReader<CollisionEvent>) {
     for event in events.iter() {
         match event {
-            CollisionEvent::Started(e1, e2) => {
-                println!("Collision started between {:?} and {:?}", e1, e2)
+            CollisionEvent::Started(d1, d2) => {
+                println!("Collision started between {:?} and {:?}", d1, d2)
             }
-            CollisionEvent::Stopped(e1, e2) => {
-                println!("Collision stopped between {:?} and {:?}", e1, e2)
+            CollisionEvent::Stopped(d1, d2) => {
+                println!("Collision stopped between {:?} and {:?}", d1, d2)
             }
         }
     }

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -1,0 +1,135 @@
+use bevy::prelude::*;
+
+use heron::prelude::*;
+
+const SPEED: f32 = 300.0;
+
+#[derive(PhysicsLayer)]
+enum Layer {
+    Enemy,
+    Player,
+}
+
+struct Player;
+
+fn main() {
+    App::build()
+        .add_plugins(DefaultPlugins)
+        .add_plugin(PhysicsPlugin::default())
+        .add_startup_system(spawn_camera.system())
+        .add_startup_system(spawn_player.system())
+        .add_startup_system(spawn_enemy.system())
+        .add_system(handle_input.system())
+        .add_system(log_collisions.system())
+        .add_system(kill_enemy.system())
+        .run();
+}
+
+// ANCHOR: log-collisions
+fn log_collisions(mut events: EventReader<CollisionEvent>) {
+    for event in events.iter() {
+        match event {
+            CollisionEvent::Started(d1, d2) => {
+                println!("Collision started between {:?} and {:?}", d1, d2)
+            }
+            CollisionEvent::Stopped(d1, d2) => {
+                println!("Collision stopped between {:?} and {:?}", d1, d2)
+            }
+        }
+    }
+}
+// ANCHOR_END: log-collisions
+
+// ANCHOR: kill-enemy
+fn kill_enemy(mut commands: Commands, mut events: EventReader<CollisionEvent>) {
+    events
+        .iter()
+        // We care about when the entities "start" to collide
+        .filter(|e| e.is_started())
+        .filter_map(|event| {
+            let (entity_1, entity_2) = event.rigid_body_entities();
+            let (layers_1, layers_2) = event.collision_layers();
+            if is_player(layers_1) && is_enemy(layers_2) {
+                Some(entity_2)
+            } else if is_player(layers_2) && is_enemy(layers_1) {
+                Some(entity_1)
+            } else {
+                // This event is not the collision between an enemy and the player. We can ignore it.
+                None
+            }
+        })
+        .for_each(|enemy_entity| commands.entity(enemy_entity).despawn());
+}
+
+// Note: We check both layers each time to avoid a false-positive
+// that can occur if an entity has the default (unconfigured) `CollisionLayers`
+fn is_player(layers: CollisionLayers) -> bool {
+    layers.contains_group(Layer::Player) && !layers.contains_group(Layer::Enemy)
+}
+
+fn is_enemy(layers: CollisionLayers) -> bool {
+    !layers.contains_group(Layer::Player) && layers.contains_group(Layer::Enemy)
+}
+// ANCHOR_END: kill-enemy
+
+fn spawn_player(mut commands: Commands, mut materials: ResMut<Assets<ColorMaterial>>) {
+    let size = Vec2::new(30.0, 30.0);
+    commands
+        .spawn_bundle(SpriteBundle {
+            sprite: Sprite::new(size),
+            material: materials.add(Color::GREEN.into()),
+            transform: Transform::from_translation(Vec3::new(-400.0, 200.0, 0.0)),
+            ..Default::default()
+        })
+        .insert(Player)
+        .insert(RigidBody::Dynamic)
+        .insert(CollisionShape::Cuboid {
+            half_extends: size.extend(0.0) / 2.0,
+        })
+        .insert(Velocity::default())
+        .insert(CollisionLayers::new(Layer::Player, Layer::Enemy));
+}
+
+fn spawn_enemy(mut commands: Commands, mut materials: ResMut<Assets<ColorMaterial>>) {
+    let size = Vec2::new(30.0, 30.0);
+    commands
+        .spawn_bundle(SpriteBundle {
+            sprite: Sprite::new(size),
+            material: materials.add(Color::RED.into()),
+            transform: Transform::from_translation(Vec3::new(0.0, 200.0, 0.0)),
+            ..Default::default()
+        })
+        .insert(RigidBody::Static)
+        .insert(CollisionShape::Cuboid {
+            half_extends: size.extend(0.0) / 2.0,
+        })
+        .insert(CollisionLayers::new(Layer::Enemy, Layer::Player));
+}
+
+fn spawn_camera(mut commands: Commands) {
+    commands.spawn_bundle(OrthographicCameraBundle::new_2d());
+}
+
+fn handle_input(input: Res<Input<KeyCode>>, mut players: Query<&mut Velocity, With<Player>>) {
+    let x = if input.pressed(KeyCode::Left) {
+        -1.0
+    } else if input.pressed(KeyCode::Right) {
+        1.0
+    } else {
+        0.0
+    };
+
+    let y = if input.pressed(KeyCode::Down) {
+        -1.0
+    } else if input.pressed(KeyCode::Up) {
+        1.0
+    } else {
+        0.0
+    };
+
+    let target_velocity = Vec2::new(x, y).normalize_or_zero().extend(0.0) * SPEED;
+
+    for mut velocity in players.iter_mut() {
+        velocity.linear = target_velocity;
+    }
+}

--- a/guide/src/SUMMARY.md
+++ b/guide/src/SUMMARY.md
@@ -1,5 +1,6 @@
 # Summary
 
 - [Quickstart](quickstart.md)
-- [Collision shape in child entity](collision_shapes_in_child_entity.md)
 - [Layers](layers.md)
+- [Collision Events](events.md)
+- [Collision shape in child entity](collision_shapes_in_child_entity.md)

--- a/guide/src/events.md
+++ b/guide/src/events.md
@@ -1,0 +1,25 @@
+# Collision Events
+
+When two entities collide, a `CollisionEvent` is written to the `Events<CollisionEvent>` resource.
+
+The events contains two `CollisionData` that contains each:
+
+* The bevy `Entity` containing the concerned `RigidBody`
+* The bevy `Entity` containing the concerned `CollisionShape`
+* The `CollisionLayers` associated with the concerned `CollisionShape`
+
+You may subscribe to the events like with any other event resource in bevy:
+
+```rust,no_run,noplayground
+{{#include ../../examples/events.rs:log-collisions}}
+```
+
+Combining `CollisionData` and `CollisionLayers` can make easy to plugin gameplay logic.
+
+As an example, let's say we have a player inside the `Layer::Player` collision group, and an enemy inside the `Layer::Enemy` collision group. (see: [layers](layers.md) for more informations on layer groups/masks)
+
+If we want to kill the enemy when the player collides with it we can write something like this:
+
+```rust,no_run,noplayground
+{{#include ../../examples/events.rs:kill-enemy}}
+```

--- a/rapier/src/convert.rs
+++ b/rapier/src/convert.rs
@@ -7,11 +7,12 @@
 
 use bevy::math::prelude::*;
 
-use heron_core::AxisAngle;
+use heron_core::{AxisAngle, CollisionLayers};
 
 use crate::nalgebra::{
     self, Point2, Point3, Quaternion, UnitComplex, UnitQuaternion, Vector2, Vector3,
 };
+use crate::rapier::geometry::InteractionGroups;
 use crate::rapier::math::{Isometry, Translation, Vector};
 
 pub trait IntoBevy<T> {
@@ -164,6 +165,18 @@ impl IntoRapier<f32> for AxisAngle {
 impl IntoRapier<Vector3<f32>> for AxisAngle {
     fn into_rapier(self) -> Vector3<f32> {
         Vec3::from(self).into_rapier()
+    }
+}
+
+impl IntoRapier<InteractionGroups> for CollisionLayers {
+    fn into_rapier(self) -> InteractionGroups {
+        InteractionGroups::new(self.groups_bits(), self.masks_bits())
+    }
+}
+
+impl IntoBevy<CollisionLayers> for InteractionGroups {
+    fn into_bevy(self) -> CollisionLayers {
+        CollisionLayers::from_bits((self.0 >> 16) as u16, self.0 as u16)
     }
 }
 

--- a/rapier/src/convert.rs
+++ b/rapier/src/convert.rs
@@ -176,6 +176,7 @@ impl IntoRapier<InteractionGroups> for CollisionLayers {
 
 impl IntoBevy<CollisionLayers> for InteractionGroups {
     fn into_bevy(self) -> CollisionLayers {
+        #[allow(clippy::cast_possible_truncation)]
         CollisionLayers::from_bits((self.0 >> 16) as u16, self.0 as u16)
     }
 }

--- a/rapier/src/pipeline.rs
+++ b/rapier/src/pipeline.rs
@@ -143,7 +143,7 @@ impl EventManager {
                     {
                         (d1, d2)
                     } else {
-                        (d1, d2)
+                        (d2, d1)
                     },
                 )
             } else {

--- a/rapier/src/shape.rs
+++ b/rapier/src/shape.rs
@@ -73,10 +73,7 @@ pub(crate) fn update_collision_groups(
 ) {
     for (layers, handle) in query.iter() {
         if let Some(collider) = colliders.get_mut(*handle) {
-            collider.set_collision_groups(InteractionGroups::new(
-                layers.groups_bits(),
-                layers.masks_bits(),
-            ));
+            collider.set_collision_groups(layers.into_rapier());
         }
     }
 }
@@ -155,10 +152,7 @@ trait ColliderFactory {
         }
 
         if let Some(layers) = layers {
-            builder = builder.collision_groups(InteractionGroups::new(
-                layers.groups_bits(),
-                layers.masks_bits(),
-            ));
+            builder = builder.collision_groups(layers.into_rapier());
         }
 
         builder.build()

--- a/rapier/tests/events.rs
+++ b/rapier/tests/events.rs
@@ -72,13 +72,11 @@ fn collision_events_are_fired() {
     app.update();
     events.append(&mut collect_events(&app, &mut event_reader));
 
-    assert_eq!(
-        events,
-        vec![
-            CollisionEvent::Started(entity1, entity2),
-            CollisionEvent::Stopped(entity1, entity2)
-        ]
-    );
+    assert_eq!(events.len(), 2);
+    assert!(matches!(events[0], CollisionEvent::Started(_, _)));
+    assert!(matches!(events[1], CollisionEvent::Stopped(_, _)));
+    assert_eq!(events[0].collision_shape_entities(), (entity1, entity2));
+    assert_eq!(events[1].collision_shape_entities(), (entity1, entity2));
 }
 
 fn collect_events(


### PR DESCRIPTION
Resolve #99 

## This is a breaking change!

The `CollisionEvent` now contains a pair of `CollisionData` instead of a pair of `Entity`.

Each `CollisionData` contains:
* The entity of the `RigidBody`
* The entity of the `CollisionShape`
* The `CollisionLayers`