### PR TITLE
feat: SensorShape component to mark individual collision shape as sensor

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -91,6 +91,7 @@ impl Plugin for CorePlugin {
             .register_type::<Acceleration>()
             .register_type::<RotationConstraints>()
             .register_type::<CollisionLayers>()
+            .register_type::<Sensor>()
             .add_stage_before(CoreStage::PostUpdate, crate::stage::ROOT, {
                 let mut schedule = Schedule::default();
 
@@ -226,6 +227,39 @@ impl RigidBody {
         }
     }
 }
+
+/// Mark the [`CollisionShape`] of the same entity as being a *sensor*.
+///
+/// This is especially useful to add sensor to an existing (non-sensor) rigid body without the need to create a [`RigidBody::Sensor`] in between.
+///
+/// It has no effect if the concerned rigid body is already a [`RigidBody::Sensor`].
+///
+/// # Example
+///
+/// ```rust
+/// # use heron_core::*;
+/// # use bevy::prelude::*;
+/// fn spawn(mut commands: Commands, mut materials: ResMut<Assets<ColorMaterial>>) {
+///   commands.spawn_bundle(todo!("Spawn your sprite/mesh, incl. at least a GlobalTransform"))
+///     .insert(RigidBody::Dynamic) // <-- A non-sensor rigid body
+///     .with_children(|children| {
+///       children.spawn_bundle((
+///             CollisionShape::Sphere { radius: 1.0 }, // <-- A physics collision shape
+///             Transform::default(), // <-- Optionally define it's position
+///             GlobalTransform::default(),
+///       ));
+///  
+///       children.spawn_bundle((
+///           CollisionShape::Sphere { radius: 1.0 }, // <-- A *sensor* collision shape.
+///           Sensor,
+///           Transform::default(), // <-- Optionally define it's position
+///           GlobalTransform::default(),
+///       ));
+///     });
+/// }
+/// ```
+#[derive(Debug, Copy, Clone, Default, Reflect)]
+pub struct Sensor;
 
 /// Component that defines the physics properties of the rigid body
 ///

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -91,7 +91,7 @@ impl Plugin for CorePlugin {
             .register_type::<Acceleration>()
             .register_type::<RotationConstraints>()
             .register_type::<CollisionLayers>()
-            .register_type::<Sensor>()
+            .register_type::<SensorShape>()
             .add_stage_before(CoreStage::PostUpdate, crate::stage::ROOT, {
                 let mut schedule = Schedule::default();
 
@@ -251,7 +251,7 @@ impl RigidBody {
 ///  
 ///       children.spawn_bundle((
 ///           CollisionShape::Sphere { radius: 1.0 }, // <-- A *sensor* collision shape.
-///           Sensor,
+///           SensorShape,
 ///           Transform::default(), // <-- Optionally define it's position
 ///           GlobalTransform::default(),
 ///       ));
@@ -259,7 +259,7 @@ impl RigidBody {
 /// }
 /// ```
 #[derive(Debug, Copy, Clone, Default, Reflect)]
-pub struct Sensor;
+pub struct SensorShape;
 
 /// Component that defines the physics properties of the rigid body
 ///

--- a/examples/collision_shapes_in_child_entity.rs
+++ b/examples/collision_shapes_in_child_entity.rs
@@ -19,32 +19,40 @@ fn spawn(mut commands: Commands) {
 
     // ANCHOR: add-child-shape
     rigid_body_entity
-        // The rigid body
+        // A (parent) dynamic rigid body
         .insert(RigidBody::Dynamic)
+        .insert(Transform::from_translation(Vec3::new(-400.0, 200.0, 0.0)))
+        .insert(GlobalTransform::default())
         .with_children(|children| {
+            // A first physics shape
             children.spawn_bundle((
-                // Position of the shape relative to its parent
-                Transform::from_translation(Vec3::Y * 15.0),
                 CollisionShape::Cuboid {
                     half_extends: Vec3::new(15.0, 15.0, 0.0),
                 },
+                Transform::default(),
                 GlobalTransform::default(),
             ));
 
+            // A second physics shape
             children.spawn_bundle((
-                // Position of the shape relative to its parent
-                Transform::from_translation(Vec3::X * 100.0),
                 CollisionShape::Cuboid {
                     half_extends: Vec3::new(50.0, 50.0, 0.0),
                 },
+                Transform::from_translation(Vec3::X * 100.0),
+                GlobalTransform::default(),
+            ));
+
+            // A sensor
+            children.spawn_bundle((
+                SensorShape,
+                CollisionShape::Sphere { radius: 30.0 },
+                Transform::from_translation(Vec3::X * -100.0),
                 GlobalTransform::default(),
             ));
         });
     // ANCHOR_END: add-child-shape
 
     rigid_body_entity
-        .insert(Transform::from_translation(Vec3::new(-400.0, 200.0, 0.0)))
-        .insert(GlobalTransform::default())
         .insert(Velocity::from(Vec2::X * 150.0).with_angular(AxisAngle::new(Vec3::Z, PI * -0.7)))
         .insert(PhysicMaterial {
             restitution: 0.7,

--- a/guide/src/collision_shapes_in_child_entity.md
+++ b/guide/src/collision_shapes_in_child_entity.md
@@ -1,15 +1,15 @@
 # Collision shapes in child entity
 
-The `CollisionShape` component doesn't have to be on the same entity than the `RigidBody` component. It can also be on a
-direct child entity of the `RigidBody` component.
+The `CollisionShape` component doesn't have to be on the same entity as the `RigidBody`. It can also be on a direct
+child entity of the `RigidBody` component.
+
+This can be useful to position/rotate the shape relatively to its parent rigid body.
+
+It is also possible to add multiple collision shape for a single rigid body. When doing so the `SensorShape` component
+can be added to create a mix of physics and sensor shapes.
 
 Example:
 
 ```rust,no_run,noplayground
 {{#include ../../examples/collision_shapes_in_child_entity.rs:add-child-shape}}
 ```
-
-This makes possible to:
-
-* define the position and rotation of the collision shape relative to its parent rigid body.
-* define multiple collision shapes for a single rigid body.

--- a/rapier/src/body.rs
+++ b/rapier/src/body.rs
@@ -141,29 +141,6 @@ fn remove_collider_handles(
         });
 }
 
-pub(crate) fn update_rapier_status(
-    mut bodies: ResMut<'_, RigidBodySet>,
-    with_type_changed: Query<'_, (&RigidBody, &RigidBodyHandle), Changed<RigidBody>>,
-    with_body_handle: Query<'_, (Entity, &RigidBodyHandle)>,
-    type_removed: RemovedComponents<'_, RigidBody>,
-) {
-    for (body_type, handle) in with_type_changed.iter() {
-        if let Some(body) = bodies.get_mut(*handle) {
-            body.set_body_status(body_status(*body_type));
-        }
-    }
-
-    for entity in type_removed.iter() {
-        if let Some(body) = with_body_handle
-            .get(entity)
-            .ok()
-            .and_then(|(_, handle)| bodies.get_mut(*handle))
-        {
-            body.set_body_status(body_status(RigidBody::default()));
-        }
-    }
-}
-
 pub(crate) fn update_rapier_position(
     mut bodies: ResMut<'_, RigidBodySet>,
     query: Query<'_, (&GlobalTransform, &RigidBodyHandle), Changed<GlobalTransform>>,

--- a/rapier/src/lib.rs
+++ b/rapier/src/lib.rs
@@ -160,7 +160,6 @@ fn update_rapier_world_stage() -> SystemStage {
                 .after(PhysicsSystem::TransformPropagation),
         )
         .with_system(velocity::update_rapier_velocity.system())
-        .with_system(body::update_rapier_status.system())
         .with_system(acceleration::update_rapier_force_and_torque.system())
         .with_system(shape::update_position.system())
         .with_system(shape::update_collision_groups.system())

--- a/rapier/src/lib.rs
+++ b/rapier/src/lib.rs
@@ -165,6 +165,7 @@ fn update_rapier_world_stage() -> SystemStage {
         .with_system(shape::update_position.system())
         .with_system(shape::update_collision_groups.system())
         .with_system(shape::update_sensor_flag.system())
+        .with_system(shape::remove_sensor_flag.system())
         .with_system(shape::reset_collision_groups.system())
 }
 

--- a/rapier/src/lib.rs
+++ b/rapier/src/lib.rs
@@ -164,6 +164,7 @@ fn update_rapier_world_stage() -> SystemStage {
         .with_system(acceleration::update_rapier_force_and_torque.system())
         .with_system(shape::update_position.system())
         .with_system(shape::update_collision_groups.system())
+        .with_system(shape::update_sensor_flag.system())
         .with_system(shape::reset_collision_groups.system())
 }
 

--- a/rapier/src/shape.rs
+++ b/rapier/src/shape.rs
@@ -102,6 +102,18 @@ pub(crate) fn update_sensor_flag(
     }
 }
 
+pub(crate) fn remove_sensor_flag(
+    mut colliders: ResMut<'_, ColliderSet>,
+    handles: Query<'_, &ColliderHandle>,
+    removed: RemovedComponents<'_, SensorShape>,
+) {
+    for handle in removed.iter().filter_map(|e| handles.get(e).ok()) {
+        if let Some(collider) = colliders.get_mut(*handle) {
+            collider.set_sensor(false);
+        }
+    }
+}
+
 pub(crate) fn reset_collision_groups(
     mut colliders: ResMut<'_, ColliderSet>,
     handles: Query<'_, &ColliderHandle>,

--- a/rapier/src/shape.rs
+++ b/rapier/src/shape.rs
@@ -91,6 +91,17 @@ pub(crate) fn update_collision_groups(
     }
 }
 
+pub(crate) fn update_sensor_flag(
+    mut colliders: ResMut<'_, ColliderSet>,
+    query: Query<'_, &ColliderHandle, Changed<SensorShape>>,
+) {
+    for handle in query.iter() {
+        if let Some(collider) = colliders.get_mut(*handle) {
+            collider.set_sensor(true);
+        }
+    }
+}
+
 pub(crate) fn reset_collision_groups(
     mut colliders: ResMut<'_, ColliderSet>,
     handles: Query<'_, &ColliderHandle>,

--- a/rapier/src/shape.rs
+++ b/rapier/src/shape.rs
@@ -102,6 +102,7 @@ pub(crate) fn update_sensor_flag(
     }
 }
 
+#[allow(clippy::cast_possible_truncation)]
 pub(crate) fn remove_sensor_flag(
     bodies: Res<'_, RigidBodySet>,
     mut colliders: ResMut<'_, ColliderSet>,

--- a/rapier/tests/sensor_shape.rs
+++ b/rapier/tests/sensor_shape.rs
@@ -1,0 +1,60 @@
+#![cfg(all(
+    any(feature = "2d", feature = "3d"),
+    not(all(feature = "2d", feature = "3d")),
+))]
+
+use bevy::app::{Events, ManualEventReader};
+use bevy::core::CorePlugin;
+use bevy::prelude::*;
+use bevy::reflect::TypeRegistryArc;
+
+use heron_core::{CollisionShape, RigidBody, SensorShape};
+use heron_rapier::rapier::dynamics::IntegrationParameters;
+use heron_rapier::rapier::geometry::ColliderSet;
+use heron_rapier::RapierPlugin;
+
+fn test_app() -> App {
+    let mut builder = App::build();
+    let mut parameters = IntegrationParameters::default();
+    parameters.dt = 1.0;
+
+    builder
+        .init_resource::<TypeRegistryArc>()
+        .add_plugin(CorePlugin)
+        .add_plugin(RapierPlugin {
+            step_per_second: None,
+            parameters,
+        })
+        .add_system_to_stage(
+            bevy::app::CoreStage::PostUpdate,
+            bevy::transform::transform_propagate_system::transform_propagate_system.system(),
+        );
+    builder.app
+}
+
+#[test]
+fn a_non_sensor_body_can_have_a_sensor_shape() {
+    let mut app = test_app();
+
+    let entity = app
+        .world
+        .spawn()
+        .insert_bundle((
+            GlobalTransform::default(),
+            RigidBody::Dynamic,
+            CollisionShape::Sphere { radius: 1.0 },
+            SensorShape,
+        ))
+        .id();
+
+    app.update();
+
+    let collider = app
+        .world
+        .get_resource::<ColliderSet>()
+        .unwrap()
+        .get(*app.world.get(entity).unwrap())
+        .unwrap();
+
+    assert!(collider.is_sensor());
+}

--- a/rapier/tests/sensor_shape.rs
+++ b/rapier/tests/sensor_shape.rs
@@ -3,7 +3,6 @@
     not(all(feature = "2d", feature = "3d")),
 ))]
 
-use bevy::app::ManualEventReader;
 use bevy::core::CorePlugin;
 use bevy::prelude::*;
 use bevy::reflect::TypeRegistryArc;

--- a/rapier/tests/sensor_shape.rs
+++ b/rapier/tests/sensor_shape.rs
@@ -3,7 +3,7 @@
     not(all(feature = "2d", feature = "3d")),
 ))]
 
-use bevy::app::{Events, ManualEventReader};
+use bevy::app::ManualEventReader;
 use bevy::core::CorePlugin;
 use bevy::prelude::*;
 use bevy::reflect::TypeRegistryArc;
@@ -87,4 +87,35 @@ fn sensor_flag_can_be_added_after_creation() {
         .unwrap();
 
     assert!(collider.is_sensor());
+}
+
+#[test]
+fn sensor_flag_can_removed() {
+    let mut app = test_app();
+
+    let entity = app
+        .world
+        .spawn()
+        .insert_bundle((
+            GlobalTransform::default(),
+            RigidBody::Dynamic,
+            CollisionShape::Sphere { radius: 1.0 },
+            SensorShape,
+        ))
+        .id();
+
+    app.update();
+
+    app.world.entity_mut(entity).remove::<SensorShape>();
+
+    app.update();
+
+    let collider = app
+        .world
+        .get_resource::<ColliderSet>()
+        .unwrap()
+        .get(*app.world.get(entity).unwrap())
+        .unwrap();
+
+    assert!(!collider.is_sensor());
 }

--- a/rapier/tests/sensor_shape.rs
+++ b/rapier/tests/sensor_shape.rs
@@ -58,3 +58,33 @@ fn a_non_sensor_body_can_have_a_sensor_shape() {
 
     assert!(collider.is_sensor());
 }
+
+#[test]
+fn sensor_flag_can_be_added_after_creation() {
+    let mut app = test_app();
+
+    let entity = app
+        .world
+        .spawn()
+        .insert_bundle((
+            GlobalTransform::default(),
+            RigidBody::Dynamic,
+            CollisionShape::Sphere { radius: 1.0 },
+        ))
+        .id();
+
+    app.update();
+
+    app.world.entity_mut(entity).insert(SensorShape);
+
+    app.update();
+
+    let collider = app
+        .world
+        .get_resource::<ColliderSet>()
+        .unwrap()
+        .get(*app.world.get(entity).unwrap())
+        .unwrap();
+
+    assert!(collider.is_sensor());
+}

--- a/rapier/tests/sensor_shape.rs
+++ b/rapier/tests/sensor_shape.rs
@@ -119,3 +119,34 @@ fn sensor_flag_can_removed() {
 
     assert!(!collider.is_sensor());
 }
+
+#[test]
+fn removing_sensor_flag_has_no_effect_if_body_is_sensor() {
+    let mut app = test_app();
+
+    let entity = app
+        .world
+        .spawn()
+        .insert_bundle((
+            GlobalTransform::default(),
+            RigidBody::Sensor,
+            CollisionShape::Sphere { radius: 1.0 },
+            SensorShape,
+        ))
+        .id();
+
+    app.update();
+
+    app.world.entity_mut(entity).remove::<SensorShape>();
+
+    app.update();
+
+    let collider = app
+        .world
+        .get_resource::<ColliderSet>()
+        .unwrap()
+        .get(*app.world.get(entity).unwrap())
+        .unwrap();
+
+    assert!(collider.is_sensor());
+}


### PR DESCRIPTION
Resolve #98

Add a `SensorShape` component that can mark a single collision shape as being a sensor. Even if that shape is attach to a non-sensor rigid body.

That'll make easier to define complex entities with both physics collision shapes and sensors.