### PR TITLE
feat! Runs physics step at most once per frame

### DIFF
--- a/core/src/ext.rs
+++ b/core/src/ext.rs
@@ -1,29 +1,15 @@
+#![allow(missing_docs)]
 #![deprecated(
     note = "Physics system can be added to the bevy update stage. Use bevy's add_system instead."
 )]
 
-//! Extensions to bevy API
-
 use bevy::app::AppBuilder;
 use bevy::ecs::schedule::SystemDescriptor;
 
-/// Extensions for the app builder
-#[deprecated(
-    note = "Physics system can be added to the bevy update stage. Use bevy's add_system instead."
-)]
 pub trait AppBuilderExt {
-    /// Add a system to the "physics update" stage so that it runs before each physics step.
-    ///
-    /// This can be used to add systems that modify transform/velocity or other physics components.
-    ///    
-    /// Typically (and by default) physics steps run at a fixed rate and are out of sync with the bevy update.
-    #[deprecated(
-        note = "Physics system can be added to the bevy update stage. Use bevy's add_system instead."
-    )]
     fn add_physics_system(&mut self, system: impl Into<SystemDescriptor>) -> &mut Self;
 }
 
-#[allow(deprecated)]
 impl AppBuilderExt for AppBuilder {
     fn add_physics_system(&mut self, system: impl Into<SystemDescriptor>) -> &mut Self {
         self.add_system(system)

--- a/core/src/ext.rs
+++ b/core/src/ext.rs
@@ -1,22 +1,31 @@
+#![deprecated(
+    note = "Physics system can be added to the bevy update stage. Use bevy's add_system instead."
+)]
+
 //! Extensions to bevy API
 
 use bevy::app::AppBuilder;
-use bevy::ecs::schedule::{Schedule, SystemDescriptor};
+use bevy::ecs::schedule::SystemDescriptor;
 
 /// Extensions for the app builder
+#[deprecated(
+    note = "Physics system can be added to the bevy update stage. Use bevy's add_system instead."
+)]
 pub trait AppBuilderExt {
     /// Add a system to the "physics update" stage so that it runs before each physics step.
     ///
     /// This can be used to add systems that modify transform/velocity or other physics components.
     ///    
     /// Typically (and by default) physics steps run at a fixed rate and are out of sync with the bevy update.
+    #[deprecated(
+        note = "Physics system can be added to the bevy update stage. Use bevy's add_system instead."
+    )]
     fn add_physics_system(&mut self, system: impl Into<SystemDescriptor>) -> &mut Self;
 }
 
+#[allow(deprecated)]
 impl AppBuilderExt for AppBuilder {
     fn add_physics_system(&mut self, system: impl Into<SystemDescriptor>) -> &mut Self {
-        self.stage(crate::stage::ROOT, |schedule: &mut Schedule| {
-            schedule.add_system_to_stage(crate::stage::UPDATE, system)
-        })
+        self.add_system(system)
     }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -80,7 +80,7 @@ pub fn should_run(
     physics_steps: Res<'_, PhysicsSteps>,
     physics_time: Res<'_, PhysicsTime>,
 ) -> ShouldRun {
-    if physics_steps.step_frame() && physics_time.scale() > 0.0 {
+    if physics_steps.is_step_frame() && physics_time.scale() > 0.0 {
         ShouldRun::Yes
     } else {
         ShouldRun::No

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -25,25 +25,11 @@ mod step;
 pub mod utils;
 mod velocity;
 
-/// Physics stages for user systems. These stages are executed once per physics step.
-///
-/// That usually means they don't run each frame and may run more than once in a single frame.
-///
-/// In general, end-users shouldn't have to deal with these stages directly.
-///
-/// Instead, it is possible to call the [`add_physiscs_system`](ext::AppBuilderExt::add_physics_system) extension function on `AppBuilder`
-/// to register systems that should run during the physics update.
+#[deprecated(
+    note = "Physics system can be added to the bevy update stage. Use bevy's add_system instead."
+)]
 pub mod stage {
-
-    /// The root **`Schedule`** stage
     pub const ROOT: &str = "heron-physics";
-
-    /// A **child** `SystemStage` running before each physics step.
-    ///
-    /// Use this stage to modify rigid-body transforms or any other physics component.
-    ///
-    /// **This is not a root stage**. So you cannot simply call `add_system_to_stage` on bevy's app builder.
-    /// Instead consider calling the [`add_physiscs_system`](crate::ext::AppBuilderExt::add_physics_system) extension function.
     pub const UPDATE: &str = "heron-before-step";
 }
 
@@ -53,6 +39,7 @@ pub mod stage {
 #[derive(Debug, Copy, Clone, Default)]
 pub struct CorePlugin;
 
+#[allow(deprecated)]
 impl Plugin for CorePlugin {
     fn build(&self, app: &mut AppBuilder) {
         app.init_resource::<Gravity>()

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -50,36 +50,8 @@ pub mod stage {
 /// Plugin that registers stage resources and components.
 ///
 /// It does **NOT** enable physics behavior.
-#[derive(Debug, Copy, Clone)]
-pub struct CorePlugin {
-    /// Number of physics step per second. `None` means to run physics step as part of the application update instead.
-    pub steps_per_second: Option<f64>,
-}
-
-impl Default for CorePlugin {
-    fn default() -> Self {
-        Self::from_steps_per_second(60)
-    }
-}
-
-impl CorePlugin {
-    /// Configure how many times per second the physics world needs to be updated
-    ///
-    /// # Panics
-    ///
-    /// Panic if the number of `steps_per_second` is 0
-    #[must_use]
-    pub fn from_steps_per_second(steps_per_second: u8) -> Self {
-        assert!(
-            steps_per_second > 0,
-            "Invalid number of step per second: {}",
-            steps_per_second
-        );
-        Self {
-            steps_per_second: Some(steps_per_second.into()),
-        }
-    }
-}
+#[derive(Debug, Copy, Clone, Default)]
+pub struct CorePlugin;
 
 impl Plugin for CorePlugin {
     fn build(&self, app: &mut AppBuilder) {
@@ -103,6 +75,7 @@ impl Plugin for CorePlugin {
     }
 }
 
+/// Run criteria system that decides if the physics systems should run.
 pub fn should_run(
     physics_steps: Res<'_, PhysicsSteps>,
     physics_time: Res<'_, PhysicsTime>,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -44,6 +44,9 @@ pub enum PhysicsSystem {
 
     /// System that update the bevy `Transform` component to reflect the velocity in the physics world
     TransformUpdate,
+
+    /// System that emits collision events
+    Events,
 }
 
 /// Plugin that registers stage resources and components.

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -28,6 +28,7 @@ mod velocity;
 #[deprecated(
     note = "Physics system can be added to the bevy update stage. Use bevy's add_system instead."
 )]
+#[allow(missing_docs)]
 pub mod stage {
     pub const ROOT: &str = "heron-physics";
     pub const UPDATE: &str = "heron-before-step";

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,6 +1,6 @@
 #![deny(future_incompatible, nonstandard_style)]
 #![warn(missing_docs, rust_2018_idioms, clippy::pedantic)]
-#![allow(clippy::module_name_repetitions)]
+#![allow(clippy::module_name_repetitions, clippy::needless_pass_by_value)]
 
 //! Core components and resources to use Heron
 
@@ -76,6 +76,7 @@ impl Plugin for CorePlugin {
 }
 
 /// Run criteria system that decides if the physics systems should run.
+#[must_use]
 pub fn should_run(
     physics_steps: Res<'_, PhysicsSteps>,
     physics_time: Res<'_, PhysicsTime>,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -34,6 +34,18 @@ pub mod stage {
     pub const UPDATE: &str = "heron-before-step";
 }
 
+/// Physics system labels
+///
+/// The systems run during the bevy `CoreStage::PostUpdate` stage
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, SystemLabel)]
+pub enum PhysicsSystem {
+    /// System that update the [`Velocity`] component to reflect the velocity in the physics world
+    VelocityUpdate,
+
+    /// System that update the bevy `Transform` component to reflect the velocity in the physics world
+    TransformUpdate,
+}
+
 /// Plugin that registers stage resources and components.
 ///
 /// It does **NOT** enable physics behavior.

--- a/core/src/step.rs
+++ b/core/src/step.rs
@@ -1,0 +1,68 @@
+use std::time::Duration;
+
+use bevy::prelude::*;
+
+use crate::utils::NearZero;
+
+/// Resource to control how many physics steps are performed per second.
+///
+/// Note that a maximum of 1 step will be perform per physics update. It means that if the rate of
+/// frames per second is lower than the physics step per second, the physics simulation will slows down.
+pub struct PhysicsSteps(Mode);
+
+enum Mode {
+    EveryFrame(Duration),
+    Timer(Timer),
+}
+
+impl Default for PhysicsSteps {
+    fn default() -> Self {
+        Self::from_steps_per_seconds(58.0)
+    }
+}
+
+impl PhysicsSteps {
+    /// Configure to run at the given number of steps per second
+    ///
+    /// For good results, it is better to choose a value which is *lower* than the typical frame rate of the game.
+    pub fn from_steps_per_seconds(steps_per_second: f32) -> Self {
+        assert!(
+            !steps_per_second.is_near_zero(),
+            "Invalid steps per second: {}",
+            steps_per_second
+        );
+        Self(Mode::Timer(Timer::from_seconds(
+            1.0 / steps_per_second,
+            true,
+        )))
+    }
+
+    pub fn from_delta_time(duration: Duration) -> Self {
+        assert_ne!(!duration.as_micros(), 0, "Invalid duration: {:?}", duration);
+        Self(Mode::Timer(Timer::new(duration, true)))
+    }
+
+    pub fn every_frame(duration: Duration) -> Self {
+        Self(Mode::EveryFrame(duration))
+    }
+
+    pub fn step_frame(&self) -> bool {
+        match &self.0 {
+            Mode::EveryFrame(_) => true,
+            Mode::Timer(timer) => timer.just_finished(),
+        }
+    }
+
+    pub fn duration(&self) -> Duration {
+        match &self.0 {
+            Mode::EveryFrame(duration) => *duration,
+            Mode::Timer(timer) => timer.duration(),
+        }
+    }
+
+    pub(crate) fn update(mut physics_steps: ResMut<'_, PhysicsSteps>, time: Res<'_, Time>) {
+        if let Mode::Timer(timer) = &mut physics_steps.0 {
+            timer.tick(time.delta());
+        }
+    }
+}

--- a/core/src/step.rs
+++ b/core/src/step.rs
@@ -2,12 +2,14 @@ use std::time::Duration;
 
 use bevy::prelude::*;
 
-use crate::utils::NearZero;
-
 /// Resource to control how many physics steps are performed per second.
 ///
-/// Note that a maximum of 1 step will be perform per physics update. It means that if the rate of
+/// Note that the physics update will be performed at most once per frame. It means that if the rate of
 /// frames per second is lower than the physics step per second, the physics simulation will slows down.
+///
+/// This resource is used to tune the precision and performance of the physics system.
+/// It doesn't change the speed of the simulation.
+/// To change the time scale, look at the [`PhysicsTime`](crate::PhysicsTime) resource instead.
 pub struct PhysicsSteps(Mode);
 
 enum Mode {
@@ -24,10 +26,17 @@ impl Default for PhysicsSteps {
 impl PhysicsSteps {
     /// Configure to run at the given number of steps per second
     ///
-    /// For good results, it is better to choose a value which is *lower* than the typical frame rate of the game.
+    /// The higher the value, the more precise and the more expensive the physics simulation will be.
+    /// If the value gets higher than the frame rate of the game, the physics simulation will slows down.
+    ///
+    /// For good results, it is better to choose a value as high as possible but lower than the typical frame rate of the game.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the argument is nan, infinite or negative
     pub fn from_steps_per_seconds(steps_per_second: f32) -> Self {
         assert!(
-            !steps_per_second.is_near_zero(),
+            steps_per_second.is_finite() && steps_per_second > 0.0,
             "Invalid steps per second: {}",
             steps_per_second
         );
@@ -37,22 +46,44 @@ impl PhysicsSteps {
         )))
     }
 
+    /// Configure the physics systems to wait for the given duration before running again
+    ///
+    /// The lower the value, the more precise and the more expensive the physics simulation will be.
+    /// If the value gets lower than the delta time between each frame of the game, the physics simulation will slows down.
+    ///
+    /// For good results, it is better to choose a value as low as possible, but higher than the typical delay between each frame of the game.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the duration is zero
     pub fn from_delta_time(duration: Duration) -> Self {
-        assert_ne!(!duration.as_micros(), 0, "Invalid duration: {:?}", duration);
+        assert_ne!(!duration.as_nanos(), 0, "Invalid duration: {:?}", duration);
         Self(Mode::Timer(Timer::new(duration, true)))
     }
 
+    /// Configure the physics systems to run at each and every frame. Regardless of the current FPS.
+    ///
+    /// It takes a duration which is "haw much" the physics simulation should advance at each frame.
+    ///
+    /// Should NOT be used in production. It is mostly useful for testing purposes.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the duration is zero
     pub fn every_frame(duration: Duration) -> Self {
+        assert_ne!(!duration.as_micros(), 0, "Invalid duration: {:?}", duration);
         Self(Mode::EveryFrame(duration))
     }
 
-    pub fn step_frame(&self) -> bool {
+    /// Returns true only if the current frame is a frame that execute a physics simulation step
+    pub fn is_step_frame(&self) -> bool {
         match &self.0 {
             Mode::EveryFrame(_) => true,
             Mode::Timer(timer) => timer.just_finished(),
         }
     }
 
+    /// Time that elapses between each physics step
     pub fn duration(&self) -> Duration {
         match &self.0 {
             Mode::EveryFrame(duration) => *duration,
@@ -61,8 +92,46 @@ impl PhysicsSteps {
     }
 
     pub(crate) fn update(mut physics_steps: ResMut<'_, PhysicsSteps>, time: Res<'_, Time>) {
-        if let Mode::Timer(timer) = &mut physics_steps.0 {
-            timer.tick(time.delta());
+        physics_steps.do_update(time.delta());
+    }
+
+    #[inline]
+    fn do_update(&mut self, delta: Duration) {
+        if let Mode::Timer(timer) = &mut self.0 {
+            timer.tick(delta);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+
+    #[rstest]
+    #[case(PhysicsSteps::from_delta_time(Duration::from_secs(1)), 0.9)]
+    #[case(PhysicsSteps::from_delta_time(Duration::from_secs_f32(0.016)), 0.01)]
+    #[case(PhysicsSteps::from_steps_per_seconds(10.0), 0.09)]
+    fn is_not_step_frame_if_not_enough_time_has_elapsed(
+        #[case] mut steps: PhysicsSteps,
+        #[case] delta_time: f32,
+    ) {
+        steps.do_update(Duration::from_secs_f32(delta_time));
+        assert!(!steps.is_step_frame())
+    }
+
+    #[rstest]
+    #[case(PhysicsSteps::from_delta_time(Duration::from_secs(1)), 1.01)]
+    #[case(PhysicsSteps::from_delta_time(Duration::from_secs_f32(0.016)), 0.017)]
+    #[case(PhysicsSteps::from_steps_per_seconds(10.0), 0.11)]
+    #[case(PhysicsSteps::every_frame(Duration::from_secs(1)), 1.1)]
+    #[case(PhysicsSteps::every_frame(Duration::from_secs(1)), 0.9)]
+    fn is_step_frame_when_enough_time_has_elapsed(
+        #[case] mut steps: PhysicsSteps,
+        #[case] delta_time: f32,
+    ) {
+        steps.do_update(Duration::from_secs_f32(delta_time));
+        assert!(steps.is_step_frame())
     }
 }

--- a/core/src/step.rs
+++ b/core/src/step.rs
@@ -34,6 +34,7 @@ impl PhysicsSteps {
     /// # Panics
     ///
     /// Panics if the argument is nan, infinite or negative
+    #[must_use]
     pub fn from_steps_per_seconds(steps_per_second: f32) -> Self {
         assert!(
             steps_per_second.is_finite() && steps_per_second > 0.0,
@@ -56,6 +57,7 @@ impl PhysicsSteps {
     /// # Panics
     ///
     /// Panics if the duration is zero
+    #[must_use]
     pub fn from_delta_time(duration: Duration) -> Self {
         assert_ne!(!duration.as_nanos(), 0, "Invalid duration: {:?}", duration);
         Self(Mode::Timer(Timer::new(duration, true)))
@@ -70,12 +72,14 @@ impl PhysicsSteps {
     /// # Panics
     ///
     /// Panics if the duration is zero
+    #[must_use]
     pub fn every_frame(duration: Duration) -> Self {
         assert_ne!(!duration.as_micros(), 0, "Invalid duration: {:?}", duration);
         Self(Mode::EveryFrame(duration))
     }
 
     /// Returns true only if the current frame is a frame that execute a physics simulation step
+    #[must_use]
     pub fn is_step_frame(&self) -> bool {
         match &self.0 {
             Mode::EveryFrame(_) => true,
@@ -84,6 +88,7 @@ impl PhysicsSteps {
     }
 
     /// Time that elapses between each physics step
+    #[must_use]
     pub fn duration(&self) -> Duration {
         match &self.0 {
             Mode::EveryFrame(duration) => *duration,

--- a/debug/src/dim2.rs
+++ b/debug/src/dim2.rs
@@ -11,7 +11,14 @@ use heron_rapier::rapier::geometry::{ColliderHandle, ColliderSet, Shape};
 
 use super::*;
 
-pub(crate) fn create_debug_sprites(
+pub(crate) fn systems() -> SystemSet {
+    SystemSet::new()
+        .with_system(dim2::delete_debug_sprite.system())
+        .with_system(dim2::replace_debug_sprite.system())
+        .with_system(dim2::create_debug_sprites.system())
+}
+
+fn create_debug_sprites(
     mut commands: Commands<'_>,
     colliders: Res<'_, ColliderSet>,
     query: Query<
@@ -40,7 +47,7 @@ pub(crate) fn create_debug_sprites(
     }
 }
 
-pub(crate) fn replace_debug_sprite(
+fn replace_debug_sprite(
     mut commands: Commands<'_>,
     mut map: ResMut<'_, DebugEntityMap>,
     colliders: Res<'_, ColliderSet>,
@@ -70,7 +77,7 @@ pub(crate) fn replace_debug_sprite(
     }
 }
 
-pub(crate) fn delete_debug_sprite(
+fn delete_debug_sprite(
     mut commands: Commands<'_>,
     mut map: ResMut<'_, DebugEntityMap>,
     removed_bodies: RemovedComponents<'_, CollisionShape>,

--- a/debug/src/lib.rs
+++ b/debug/src/lib.rs
@@ -45,32 +45,14 @@ impl Default for DebugPlugin {
 impl Plugin for DebugPlugin {
     fn build(&self, app: &mut AppBuilder) {
         #[cfg(feature = "2d")]
-        app.add_plugin(bevy_prototype_lyon::plugin::ShapePlugin);
+        app.add_plugin(bevy_prototype_lyon::plugin::ShapePlugin)
+            .add_system_set_to_stage(CoreStage::PostUpdate, dim2::systems());
 
         app.insert_resource(DebugColor(self.0))
             .init_resource::<DebugEntityMap>()
-            .stage(heron_core::stage::ROOT, |schedule: &mut Schedule| {
-                schedule.add_stage_after(heron_core::stage::UPDATE, "heron-debug", debug_stage())
-            });
+            .add_system_to_stage(CoreStage::Last, track_debug_entities.system())
+            .add_system_to_stage(CoreStage::Last, scale_debug_entities.system());
     }
-}
-
-fn debug_stage() -> SystemStage {
-    let mut stage = SystemStage::single_threaded();
-
-    #[cfg(feature = "2d")]
-    {
-        stage
-            .add_system(dim2::delete_debug_sprite.system())
-            .add_system(dim2::replace_debug_sprite.system())
-            .add_system(dim2::create_debug_sprites.system());
-    }
-
-    stage
-        .add_system(track_debug_entities.system())
-        .add_system(scale_debug_entities.system());
-
-    stage
 }
 
 impl From<Color> for DebugColor {

--- a/guide/src/SUMMARY.md
+++ b/guide/src/SUMMARY.md
@@ -4,3 +4,4 @@
 - [Layers](layers.md)
 - [Collision Events](events.md)
 - [Collision shape in child entity](collision_shapes_in_child_entity.md)
+- [Interacting with physics](interaction.md)

--- a/guide/src/interaction.md
+++ b/guide/src/interaction.md
@@ -1,0 +1,11 @@
+# Interacting with physics
+
+Heron aims to make interaction with physics as straight forward as possible.
+
+In general all you have to do is read/mutate for the relevant components. (`Transform`, `Velocity`, `Acceleration`, etc.)
+
+That being said. To avoid frame delay, consider the following advices:
+
+1. Mutate the components during the `CoreStage::Update` stage. (Or before)
+2. React on the physics results in the `CoreStage::PostUpdate` stage, and use `PhysicsSystem` labels to declare after
+   which system it should run.

--- a/rapier/src/lib.rs
+++ b/rapier/src/lib.rs
@@ -37,7 +37,6 @@ pub struct RapierPlugin;
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, SystemLabel)]
 enum InternalSystem {
     TransformPropagation,
-    Step,
 }
 
 impl Plugin for RapierPlugin {
@@ -108,24 +107,24 @@ fn step_systems() -> SystemSet {
         .with_system(
             velocity::apply_velocity_to_kinematic_bodies
                 .system()
-                .before(InternalSystem::Step),
+                .before(PhysicsSystem::Events),
         )
         .with_system(
             pipeline::update_integration_parameters
                 .system()
-                .before(InternalSystem::Step),
+                .before(PhysicsSystem::Events),
         )
-        .with_system(pipeline::step.system().label(InternalSystem::Step))
+        .with_system(pipeline::step.system().label(PhysicsSystem::Events))
         .with_system(
             body::update_bevy_transform
                 .system()
                 .label(PhysicsSystem::TransformUpdate)
-                .after(InternalSystem::Step),
+                .after(PhysicsSystem::Events),
         )
         .with_system(
             velocity::update_velocity_component
                 .system()
                 .label(PhysicsSystem::VelocityUpdate)
-                .after(InternalSystem::Step),
+                .after(PhysicsSystem::Events),
         )
 }

--- a/rapier/src/lib.rs
+++ b/rapier/src/lib.rs
@@ -61,7 +61,7 @@ impl Plugin for RapierPlugin {
             .insert_resource(ColliderSet::new())
             .insert_resource(JointSet::new())
             .insert_resource(CCDSolver::new())
-            .stage(heron_core::stage::ROOT, |schedule: &mut Schedule| {
+            .stage("heron-physics", |schedule: &mut Schedule| {
                 schedule
                     .add_stage("heron-remove", removal_stage())
                     .add_stage("heron-update-rapier-world", update_rapier_world_stage())

--- a/rapier/src/pipeline.rs
+++ b/rapier/src/pipeline.rs
@@ -3,7 +3,7 @@ use bevy::ecs::prelude::*;
 use bevy::math::Vec3;
 use crossbeam::channel::Receiver;
 
-use heron_core::{CollisionData, CollisionEvent, Gravity, PhysicsTime};
+use heron_core::{CollisionData, CollisionEvent, Gravity, PhysicsSteps, PhysicsTime};
 
 use crate::convert::{IntoBevy, IntoRapier};
 use crate::rapier::dynamics::{CCDSolver, IntegrationParameters, JointSet, RigidBodySet};
@@ -12,18 +12,13 @@ use crate::rapier::geometry::{
 };
 use crate::rapier::pipeline::{ChannelEventCollector, PhysicsPipeline};
 
-#[derive(Copy, Clone)]
-pub(crate) struct PhysicsStepPerSecond(pub(crate) f32);
-
 pub(crate) fn update_integration_parameters(
-    steps_per_second: Option<Res<'_, PhysicsStepPerSecond>>,
+    physics_steps: Res<'_, PhysicsSteps>,
     physics_time: Res<'_, PhysicsTime>,
     mut integration_parameters: ResMut<'_, IntegrationParameters>,
 ) {
-    if let Some(steps_per_second) = steps_per_second {
-        if steps_per_second.is_changed() {
-            integration_parameters.dt = physics_time.scale() / steps_per_second.0;
-        }
+    if physics_steps.is_changed() || physics_time.is_changed() {
+        integration_parameters.dt = physics_steps.duration().as_secs_f32() * physics_time.scale();
     }
 }
 

--- a/rapier/src/velocity.rs
+++ b/rapier/src/velocity.rs
@@ -5,7 +5,7 @@ use heron_core::utils::NearZero;
 use heron_core::{PhysicsSteps, RigidBody, Velocity};
 
 use crate::convert::{IntoBevy, IntoRapier};
-use crate::rapier::dynamics::{IntegrationParameters, RigidBodyHandle, RigidBodySet};
+use crate::rapier::dynamics::{RigidBodyHandle, RigidBodySet};
 
 pub(crate) fn update_rapier_velocity(
     mut bodies: ResMut<'_, RigidBodySet>,

--- a/rapier/src/velocity.rs
+++ b/rapier/src/velocity.rs
@@ -2,7 +2,7 @@ use bevy::ecs::prelude::*;
 use bevy::math::prelude::*;
 
 use heron_core::utils::NearZero;
-use heron_core::{RigidBody, Velocity};
+use heron_core::{PhysicsSteps, RigidBody, Velocity};
 
 use crate::convert::{IntoBevy, IntoRapier};
 use crate::rapier::dynamics::{IntegrationParameters, RigidBodyHandle, RigidBodySet};
@@ -26,10 +26,10 @@ pub(crate) fn update_rapier_velocity(
 
 pub(crate) fn apply_velocity_to_kinematic_bodies(
     mut bodies: ResMut<'_, RigidBodySet>,
-    integration_parameters: Res<'_, IntegrationParameters>,
+    physics_step: Res<'_, PhysicsSteps>,
     query: Query<'_, (&RigidBodyHandle, &RigidBody, &Velocity)>,
 ) {
-    let delta_time = integration_parameters.dt;
+    let delta_time = physics_step.duration().as_secs_f32();
     let kinematic_bodies = query
         .iter()
         .filter(|(_, body_type, _)| matches!(body_type, RigidBody::Kinematic));

--- a/rapier/tests/acceleration.rs
+++ b/rapier/tests/acceleration.rs
@@ -8,28 +8,20 @@ use bevy::prelude::*;
 use bevy::prelude::{GlobalTransform, Transform};
 use bevy::reflect::TypeRegistryArc;
 
-use heron_core::{Acceleration, AxisAngle, CollisionShape, RigidBody};
+use heron_core::{Acceleration, AxisAngle, CollisionShape, PhysicsSteps, RigidBody};
 use heron_rapier::convert::IntoBevy;
 #[cfg(feature = "3d")]
 use heron_rapier::rapier::math::Vector;
-use heron_rapier::{
-    rapier::dynamics::{IntegrationParameters, RigidBodySet},
-    RapierPlugin,
-};
+use heron_rapier::{rapier::dynamics::RigidBodySet, RapierPlugin};
+use std::time::Duration;
 
 fn test_app() -> App {
     let mut builder = App::build();
     builder
         .init_resource::<TypeRegistryArc>()
+        .insert_resource(PhysicsSteps::every_frame(Duration::from_secs(1)))
         .add_plugin(CorePlugin)
-        .add_plugin(RapierPlugin {
-            step_per_second: None,
-            parameters: {
-                let mut params = IntegrationParameters::default();
-                params.dt = 1.0;
-                params
-            },
-        });
+        .add_plugin(RapierPlugin);
     builder.app
 }
 

--- a/rapier/tests/bodies.rs
+++ b/rapier/tests/bodies.rs
@@ -5,14 +5,15 @@
 
 use std::f32::consts::PI;
 use std::ops::DerefMut;
+use std::time::Duration;
 
 use bevy::core::CorePlugin;
 use bevy::prelude::*;
 use bevy::reflect::TypeRegistryArc;
 
-use heron_core::{CollisionShape, RigidBody};
+use heron_core::{CollisionShape, PhysicsSteps, RigidBody};
 use heron_rapier::convert::IntoBevy;
-use heron_rapier::rapier::dynamics::{IntegrationParameters, RigidBodyHandle, RigidBodySet};
+use heron_rapier::rapier::dynamics::{RigidBodyHandle, RigidBodySet};
 use heron_rapier::rapier::geometry::{ColliderHandle, ColliderSet};
 use heron_rapier::RapierPlugin;
 
@@ -20,12 +21,9 @@ fn test_app() -> App {
     let mut builder = App::build();
     builder
         .init_resource::<TypeRegistryArc>()
+        .insert_resource(PhysicsSteps::every_frame(Duration::from_secs(1)))
         .add_plugin(CorePlugin)
-        .add_plugin(RapierPlugin {
-            step_per_second: None,
-            parameters: IntegrationParameters::default(),
-        });
-
+        .add_plugin(RapierPlugin);
     builder.app
 }
 

--- a/rapier/tests/body_types.rs
+++ b/rapier/tests/body_types.rs
@@ -3,12 +3,14 @@
     not(all(feature = "2d", feature = "3d")),
 ))]
 
+use std::time::Duration;
+
 use bevy::core::CorePlugin;
 use bevy::prelude::*;
 use bevy::reflect::TypeRegistryArc;
 
-use heron_core::{CollisionShape, RigidBody};
-use heron_rapier::rapier::dynamics::{IntegrationParameters, RigidBodySet};
+use heron_core::{CollisionShape, PhysicsSteps, RigidBody};
+use heron_rapier::rapier::dynamics::RigidBodySet;
 use heron_rapier::rapier::geometry::ColliderSet;
 use heron_rapier::RapierPlugin;
 
@@ -16,11 +18,9 @@ fn test_app() -> App {
     let mut builder = App::build();
     builder
         .init_resource::<TypeRegistryArc>()
+        .insert_resource(PhysicsSteps::every_frame(Duration::from_secs(1)))
         .add_plugin(CorePlugin)
-        .add_plugin(RapierPlugin {
-            step_per_second: None,
-            parameters: IntegrationParameters::default(),
-        });
+        .add_plugin(RapierPlugin);
     builder.app
 }
 

--- a/rapier/tests/children_collision_shapes.rs
+++ b/rapier/tests/children_collision_shapes.rs
@@ -3,13 +3,15 @@
     not(all(feature = "2d", feature = "3d")),
 ))]
 
+use std::time::Duration;
+
 use bevy::core::CorePlugin;
 use bevy::prelude::*;
 use bevy::reflect::TypeRegistryArc;
 
-use heron_core::{CollisionShape, RigidBody};
+use heron_core::{CollisionShape, PhysicsSteps, RigidBody};
 use heron_rapier::convert::IntoBevy;
-use heron_rapier::rapier::dynamics::{IntegrationParameters, RigidBodySet};
+use heron_rapier::rapier::dynamics::RigidBodySet;
 use heron_rapier::rapier::geometry::ColliderSet;
 use heron_rapier::RapierPlugin;
 
@@ -17,11 +19,9 @@ fn test_app() -> App {
     let mut builder = App::build();
     builder
         .init_resource::<TypeRegistryArc>()
+        .insert_resource(PhysicsSteps::every_frame(Duration::from_secs(1)))
         .add_plugin(CorePlugin)
-        .add_plugin(RapierPlugin {
-            step_per_second: None,
-            parameters: IntegrationParameters::default(),
-        });
+        .add_plugin(RapierPlugin);
 
     builder.app
 }

--- a/rapier/tests/constraints.rs
+++ b/rapier/tests/constraints.rs
@@ -1,22 +1,22 @@
 #![cfg(feature = "2d")]
 
+use std::time::Duration;
+
 use bevy::core::CorePlugin;
 use bevy::prelude::*;
 use bevy::reflect::TypeRegistryArc;
 
-use heron_core::{CollisionShape, RigidBody, RotationConstraints};
-use heron_rapier::rapier::dynamics::{IntegrationParameters, RigidBodySet};
+use heron_core::{CollisionShape, PhysicsSteps, RigidBody, RotationConstraints};
+use heron_rapier::rapier::dynamics::RigidBodySet;
 use heron_rapier::RapierPlugin;
 
 fn test_app() -> App {
     let mut builder = App::build();
     builder
         .init_resource::<TypeRegistryArc>()
+        .insert_resource(PhysicsSteps::every_frame(Duration::from_secs(1)))
         .add_plugin(CorePlugin)
-        .add_plugin(RapierPlugin {
-            step_per_second: None,
-            parameters: IntegrationParameters::default(),
-        });
+        .add_plugin(RapierPlugin);
     builder.app
 }
 

--- a/rapier/tests/density.rs
+++ b/rapier/tests/density.rs
@@ -3,25 +3,25 @@
     not(all(feature = "2d", feature = "3d")),
 ))]
 
+use std::time::Duration;
+
 use bevy::core::CorePlugin;
 use bevy::prelude::*;
 use bevy::reflect::TypeRegistryArc;
 
 use heron_core::utils::NearZero;
-use heron_core::{CollisionShape, PhysicMaterial, RigidBody};
+use heron_core::{CollisionShape, PhysicMaterial, PhysicsSteps, RigidBody};
 use heron_rapier::convert::IntoBevy;
-use heron_rapier::rapier::dynamics::{IntegrationParameters, MassProperties, RigidBodySet};
+use heron_rapier::rapier::dynamics::{MassProperties, RigidBodySet};
 use heron_rapier::RapierPlugin;
 
 fn test_app() -> App {
     let mut builder = App::build();
     builder
         .init_resource::<TypeRegistryArc>()
+        .insert_resource(PhysicsSteps::every_frame(Duration::from_secs(1)))
         .add_plugin(CorePlugin)
-        .add_plugin(RapierPlugin {
-            step_per_second: None,
-            parameters: IntegrationParameters::default(),
-        });
+        .add_plugin(RapierPlugin);
     builder.app
 }
 

--- a/rapier/tests/events.rs
+++ b/rapier/tests/events.rs
@@ -8,9 +8,10 @@ use bevy::core::CorePlugin;
 use bevy::prelude::*;
 use bevy::reflect::TypeRegistryArc;
 
-use heron_core::{CollisionEvent, CollisionShape, RigidBody, Velocity};
+use heron_core::{CollisionEvent, CollisionShape, PhysicsSteps, RigidBody, Velocity};
 use heron_rapier::rapier::dynamics::IntegrationParameters;
 use heron_rapier::RapierPlugin;
+use std::time::Duration;
 
 fn test_app() -> App {
     let mut builder = App::build();
@@ -19,11 +20,9 @@ fn test_app() -> App {
 
     builder
         .init_resource::<TypeRegistryArc>()
+        .insert_resource(PhysicsSteps::every_frame(Duration::from_secs(1)))
         .add_plugin(CorePlugin)
-        .add_plugin(RapierPlugin {
-            step_per_second: None,
-            parameters,
-        })
+        .add_plugin(RapierPlugin)
         .add_system_to_stage(
             bevy::app::CoreStage::PostUpdate,
             bevy::transform::transform_propagate_system::transform_propagate_system.system(),

--- a/rapier/tests/friction.rs
+++ b/rapier/tests/friction.rs
@@ -3,12 +3,13 @@
     not(all(feature = "2d", feature = "3d")),
 ))]
 
+use std::time::Duration;
+
 use bevy::core::CorePlugin;
 use bevy::prelude::*;
 use bevy::reflect::TypeRegistryArc;
 
-use heron_core::{CollisionShape, PhysicMaterial, RigidBody};
-use heron_rapier::rapier::dynamics::IntegrationParameters;
+use heron_core::{CollisionShape, PhysicMaterial, PhysicsSteps, RigidBody};
 use heron_rapier::rapier::geometry::ColliderSet;
 use heron_rapier::RapierPlugin;
 
@@ -16,11 +17,9 @@ fn test_app() -> App {
     let mut builder = App::build();
     builder
         .init_resource::<TypeRegistryArc>()
+        .insert_resource(PhysicsSteps::every_frame(Duration::from_secs(1)))
         .add_plugin(CorePlugin)
-        .add_plugin(RapierPlugin {
-            step_per_second: None,
-            parameters: IntegrationParameters::default(),
-        });
+        .add_plugin(RapierPlugin);
     builder.app
 }
 

--- a/rapier/tests/layers.rs
+++ b/rapier/tests/layers.rs
@@ -8,7 +8,6 @@ use bevy::prelude::*;
 use bevy::reflect::TypeRegistryArc;
 
 use heron_core::{CollisionLayers, CollisionShape, PhysicsLayer, PhysicsSteps, RigidBody};
-use heron_rapier::rapier::dynamics::IntegrationParameters;
 use heron_rapier::rapier::geometry::ColliderSet;
 use heron_rapier::RapierPlugin;
 use std::time::Duration;

--- a/rapier/tests/layers.rs
+++ b/rapier/tests/layers.rs
@@ -7,10 +7,11 @@ use bevy::core::CorePlugin;
 use bevy::prelude::*;
 use bevy::reflect::TypeRegistryArc;
 
-use heron_core::{CollisionLayers, CollisionShape, PhysicsLayer, RigidBody};
+use heron_core::{CollisionLayers, CollisionShape, PhysicsLayer, PhysicsSteps, RigidBody};
 use heron_rapier::rapier::dynamics::IntegrationParameters;
 use heron_rapier::rapier::geometry::ColliderSet;
 use heron_rapier::RapierPlugin;
+use std::time::Duration;
 
 enum TestLayer {
     A,
@@ -34,11 +35,9 @@ fn test_app() -> App {
     let mut builder = App::build();
     builder
         .init_resource::<TypeRegistryArc>()
+        .insert_resource(PhysicsSteps::every_frame(Duration::from_secs(1)))
         .add_plugin(CorePlugin)
-        .add_plugin(RapierPlugin {
-            step_per_second: None,
-            parameters: IntegrationParameters::default(),
-        });
+        .add_plugin(RapierPlugin);
     builder.app
 }
 

--- a/rapier/tests/restitution.rs
+++ b/rapier/tests/restitution.rs
@@ -7,20 +7,18 @@ use bevy::core::CorePlugin;
 use bevy::prelude::*;
 use bevy::reflect::TypeRegistryArc;
 
-use heron_core::{CollisionShape, PhysicMaterial, RigidBody};
-use heron_rapier::rapier::dynamics::IntegrationParameters;
+use heron_core::{CollisionShape, PhysicMaterial, PhysicsSteps, RigidBody};
 use heron_rapier::rapier::geometry::ColliderSet;
 use heron_rapier::RapierPlugin;
+use std::time::Duration;
 
 fn test_app() -> App {
     let mut builder = App::build();
     builder
         .init_resource::<TypeRegistryArc>()
+        .insert_resource(PhysicsSteps::every_frame(Duration::from_secs(1)))
         .add_plugin(CorePlugin)
-        .add_plugin(RapierPlugin {
-            step_per_second: None,
-            parameters: IntegrationParameters::default(),
-        });
+        .add_plugin(RapierPlugin);
     builder.app
 }
 

--- a/rapier/tests/sensor_shape.rs
+++ b/rapier/tests/sensor_shape.rs
@@ -3,11 +3,13 @@
     not(all(feature = "2d", feature = "3d")),
 ))]
 
+use std::time::Duration;
+
 use bevy::core::CorePlugin;
 use bevy::prelude::*;
 use bevy::reflect::TypeRegistryArc;
 
-use heron_core::{CollisionShape, RigidBody, SensorShape};
+use heron_core::{CollisionShape, PhysicsSteps, RigidBody, SensorShape};
 use heron_rapier::rapier::dynamics::IntegrationParameters;
 use heron_rapier::rapier::geometry::ColliderSet;
 use heron_rapier::RapierPlugin;
@@ -19,15 +21,9 @@ fn test_app() -> App {
 
     builder
         .init_resource::<TypeRegistryArc>()
+        .insert_resource(PhysicsSteps::every_frame(Duration::from_secs(1)))
         .add_plugin(CorePlugin)
-        .add_plugin(RapierPlugin {
-            step_per_second: None,
-            parameters,
-        })
-        .add_system_to_stage(
-            bevy::app::CoreStage::PostUpdate,
-            bevy::transform::transform_propagate_system::transform_propagate_system.system(),
-        );
+        .add_plugin(RapierPlugin);
     builder.app
 }
 

--- a/rapier/tests/velocity.rs
+++ b/rapier/tests/velocity.rs
@@ -4,6 +4,7 @@
 ))]
 
 use std::f32::consts::PI;
+use std::time::Duration;
 
 use bevy::core::CorePlugin;
 use bevy::prelude::*;
@@ -12,22 +13,16 @@ use rstest::rstest;
 
 use heron_core::*;
 use heron_rapier::convert::IntoBevy;
-use heron_rapier::rapier::dynamics::{IntegrationParameters, RigidBodySet};
+use heron_rapier::rapier::dynamics::RigidBodySet;
 use heron_rapier::RapierPlugin;
 
 fn test_app() -> App {
     let mut builder = App::build();
     builder
         .init_resource::<TypeRegistryArc>()
+        .insert_resource(PhysicsSteps::every_frame(Duration::from_secs(1)))
         .add_plugin(CorePlugin)
-        .add_plugin(RapierPlugin {
-            step_per_second: None,
-            parameters: {
-                let mut params = IntegrationParameters::default();
-                params.dt = 1.0;
-                params
-            },
-        });
+        .add_plugin(RapierPlugin);
     builder.app
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,61 +161,16 @@ pub mod prelude {
 }
 
 /// Plugin to install to enable collision detection and physics behavior.
-///
-/// When creating the plugin, you may choose the number of physics steps per second.
-/// For more advanced configuration, you can create the plugin from a rapier `IntegrationParameters` definition.
 #[must_use]
+#[derive(Debug, Copy, Clone, Default)]
 pub struct PhysicsPlugin {
-    rapier: RapierPlugin,
-
     #[cfg(feature = "debug")]
     debug: heron_debug::DebugPlugin,
 }
 
-impl PhysicsPlugin {
-    /// Configure how many times per second the physics world needs to be updated
-    ///
-    /// # Panics
-    ///
-    /// Panic if the number of `steps_per_second` is 0
-    pub fn from_steps_per_second(steps_per_second: u8) -> Self {
-        Self::from(RapierPlugin::from_steps_per_second(steps_per_second))
-    }
-
-    /// Returns a version using the given color to render collision shapes
-    #[cfg(feature = "debug")]
-    pub fn with_debug_color(mut self, color: bevy::render::color::Color) -> Self {
-        self.debug = color.into();
-        self
-    }
-}
-
-impl From<RapierPlugin> for PhysicsPlugin {
-    fn from(rapier: RapierPlugin) -> Self {
-        Self {
-            rapier,
-
-            #[cfg(feature = "debug")]
-            debug: Default::default(),
-        }
-    }
-}
-
-impl Default for PhysicsPlugin {
-    fn default() -> Self {
-        Self::from(RapierPlugin::default())
-    }
-}
-
-impl From<rapier_plugin::rapier::dynamics::IntegrationParameters> for PhysicsPlugin {
-    fn from(parameters: IntegrationParameters) -> Self {
-        Self::from(RapierPlugin::from(parameters))
-    }
-}
-
 impl Plugin for PhysicsPlugin {
     fn build(&self, app: &mut AppBuilder) {
-        app.add_plugin(self.rapier.clone());
+        app.add_plugin(RapierPlugin);
 
         #[cfg(feature = "debug")]
         app.add_plugin(self.debug);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,8 +125,8 @@ pub mod prelude {
     #[allow(deprecated)]
     pub use crate::{
         ext::*, stage, Acceleration, AxisAngle, CollisionEvent, CollisionLayers, CollisionShape,
-        Gravity, PhysicMaterial, PhysicsLayer, PhysicsPlugin, PhysicsTime, RigidBody,
-        RotationConstraints, Velocity,
+        Gravity, PhysicMaterial, PhysicsLayer, PhysicsPlugin, PhysicsSystem, PhysicsTime,
+        RigidBody, RotationConstraints, Velocity,
     };
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,7 +139,6 @@ use bevy::app::{AppBuilder, Plugin};
 
 pub use heron_core::*;
 pub use heron_macros::*;
-use heron_rapier::rapier::dynamics::IntegrationParameters;
 use heron_rapier::RapierPlugin;
 
 /// Physics behavior powered by [rapier](https://rapier.rs)
@@ -153,6 +152,7 @@ pub mod rapier_plugin {
 pub mod prelude {
     pub use heron_macros::*;
 
+    #[allow(deprecated)]
     pub use crate::{
         ext::*, stage, Acceleration, AxisAngle, CollisionEvent, CollisionLayers, CollisionShape,
         Gravity, PhysicMaterial, PhysicsLayer, PhysicsPlugin, PhysicsTime, RigidBody,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,36 +72,6 @@
 //! }
 //! ```
 //!
-//! ## Run systems synchronously with the physics step
-//!
-//! The physics step runs at a fixed rate (60 times per second by default) and is out of sync of the
-//! bevy frame.
-//!
-//! But modifying any physics component (such as the transform or velocity), should often be done synchronously with
-//! the physics step.
-//!
-//! The simplest way is to add these systems with `add_physics_system`:
-//!
-//! ```no_run
-//! # use bevy::prelude::*;
-//! # use heron::prelude::*;
-//! App::build()
-//!     .add_plugins(DefaultPlugins)
-//!     .add_plugin(PhysicsPlugin::default())
-//!
-//!     // This system should NOT update transforms, velocities and other physics components
-//!     // In other game engines this would be the "update" function
-//!     .add_system(cannot_update_physics.system())
-//!
-//!     // This system can update transforms, velocities and other physics components
-//!     // In other game engines this would be the "physics update" function
-//!     .add_physics_system(update_velocities.system())
-//!
-//!     .run();
-//! # fn cannot_update_physics() {}
-//! # fn update_velocities() {}
-//! ```
-//!
 //! ## Move rigid bodies programmatically
 //!
 //! When creating games, it is often useful to interact with the physics engine and move bodies programmatically.


### PR DESCRIPTION
Resolve #107 
Resolve #81 (because there is no need for `add_physics_system` anymore`)

## This is a breaking change!

* The physics step rate is not defined on the plugin type anymore. It is replaced by a `PhysicsSteps` resource.
* The `IntegrationParameters` can no longer be defined when installing the plugin. The `IntegrationParameters` should should be inserted/mutated instead.
* The `Velocity` and `Transform` are now updated during the `CoreStage::PostUpdate`. If a user-system should run *after* the physics update, it should explicitly declares that dependency using the `PhysicsSystem` labels.

The physics steps will now run *at most* once per frame.

At high* FPS the behavior hasn't changed. The physics step will not run on each frame.

At low* FPS the behavior is now different, and the physics step will run at most once per frame. (Before the physics step would run multiple times in a single frame)
This means the physics simulation will slow down in case of low FPS.

*: By "high" and "low", I mean higher or lower than the defined physics steps per second, which is 58 by default. This default can be changed by inserting a `PhysicsSteps` resource. The default is intentionally slightly lower than 60 FPS to give a small margin to keep the physics simulation smooth on games that runs at the fixed rate of 60 FPS (the default with bevy) 

This means the `add_physics_system` is now obsolete (and deprecated). One can read/mutate physics component normally in any system. As a side note, because the physics simulation is executed between the update and the post-update stages, the best is to mutate physics component during the `CoreStage::Update` (or before) and read the physics simulation result in the `CoreStage::PostUpdate` using the `PhysicsSystem` labels (or later)

It also means that one can now use `SystemSet` for systems that interacts with the physics, including reacting on state changes (#81)