### PR TITLE
Implement Rounded Cuboids and Convex Hulls

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -130,12 +130,22 @@ pub enum CollisionShape {
         ///
         /// In 2d the `z` axis is ignored
         half_extends: Vec3,
+        /// An optional border radius that will be used to round the corners of the cuboid
+        ///
+        /// This radius refers to how much to _add_ to the existing size of the cuboid, creating an
+        /// extra buffer around the un-rounded extent.
+        border_radius: Option<f32>,
     },
 
     /// A convex polygon/polyhedron shape
     ConvexHull {
         /// A vector of points describing the convex hull
         points: Vec<Vec3>,
+        /// An optional border radius that will be used to round the corners of the convex hull
+        ///
+        /// This radius refers to how much to _add_ to the existing size of the hull, creating an
+        /// extra buffer around the un-rounded mesh.
+        border_radius: Option<f32>,
     },
 
     /// A shape defined by the height of points.

--- a/debug/Cargo.toml
+++ b/debug/Cargo.toml
@@ -12,7 +12,7 @@ all-features = true
 
 [features]
 default = []
-2d = ["heron_rapier/2d", "bevy_prototype_lyon"]
+2d = ["heron_rapier/2d", "bevy_prototype_lyon", "lyon_path"]
 3d = ["heron_rapier/3d"]
 
 [dependencies]
@@ -20,4 +20,5 @@ heron_core = { version = "^0.10.0", path = "../core" }
 heron_rapier = { version = "^0.10.0", path = "../rapier" }
 bevy = { version = "^0.5.0", default-features = false, features = ["render"] }
 bevy_prototype_lyon = { version = "0.3.0", optional = true }
+lyon_path = { version = "0.17.4", optional = true }
 fnv = "^1.0"

--- a/examples/collision_shapes_in_child_entity.rs
+++ b/examples/collision_shapes_in_child_entity.rs
@@ -28,6 +28,7 @@ fn spawn(mut commands: Commands) {
             children.spawn_bundle((
                 CollisionShape::Cuboid {
                     half_extends: Vec3::new(15.0, 15.0, 0.0),
+                    border_radius: None,
                 },
                 Transform::default(),
                 GlobalTransform::default(),
@@ -37,6 +38,7 @@ fn spawn(mut commands: Commands) {
             children.spawn_bundle((
                 CollisionShape::Cuboid {
                     half_extends: Vec3::new(50.0, 50.0, 0.0),
+                    border_radius: None,
                 },
                 Transform::from_translation(Vec3::X * 100.0),
                 GlobalTransform::default(),
@@ -70,6 +72,7 @@ fn spawn_ground_and_camera(mut commands: Commands) {
         RigidBody::Static,
         CollisionShape::Cuboid {
             half_extends: Vec2::new(1500.0, 50.0).extend(0.0) / 2.0,
+            border_radius: None,
         },
     ));
 }

--- a/examples/debug.rs
+++ b/examples/debug.rs
@@ -27,6 +27,7 @@ fn spawn(mut commands: Commands) {
         ))
         .insert(CollisionShape::Cuboid {
             half_extends: Vec2::new(50.0, 50.0).extend(0.0),
+            border_radius: None,
         })
         .insert(RigidBody::Static);
 
@@ -54,6 +55,7 @@ fn spawn(mut commands: Commands) {
                 Vec3::new(50.0, 0.0, 0.0),
                 Vec3::new(-50.0, 0.0, 0.0),
             ],
+            border_radius: None,
         })
         .insert(RigidBody::Static);
 

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -32,6 +32,7 @@ fn spawn(mut commands: Commands, mut materials: ResMut<Assets<ColorMaterial>>) {
         // Attach a collision shape
         .insert(CollisionShape::Cuboid {
             half_extends: size.extend(0.0) / 2.0,
+            border_radius: None,
         })
         // Define restitution (so that it bounces)
         .insert(PhysicMaterial {
@@ -54,6 +55,7 @@ fn spawn(mut commands: Commands, mut materials: ResMut<Assets<ColorMaterial>>) {
         // Attach a collision shape
         .insert(CollisionShape::Cuboid {
             half_extends: size.extend(0.0) / 2.0,
+            border_radius: None,
         })
         // Add an initial velocity. (it is also possible to read/mutate this component later)
         .insert(Velocity::from(Vec2::X * 300.0).with_angular(AxisAngle::new(Vec3::Z, -PI)))

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -85,6 +85,7 @@ fn spawn_player(mut commands: Commands, mut materials: ResMut<Assets<ColorMateri
         .insert(RigidBody::Dynamic)
         .insert(CollisionShape::Cuboid {
             half_extends: size.extend(0.0) / 2.0,
+            border_radius: None,
         })
         .insert(Velocity::default())
         .insert(CollisionLayers::new(Layer::Player, Layer::Enemy));
@@ -102,6 +103,7 @@ fn spawn_enemy(mut commands: Commands, mut materials: ResMut<Assets<ColorMateria
         .insert(RigidBody::Static)
         .insert(CollisionShape::Cuboid {
             half_extends: size.extend(0.0) / 2.0,
+            border_radius: None,
         })
         .insert(CollisionLayers::new(Layer::Enemy, Layer::Player));
 }

--- a/examples/layers.rs
+++ b/examples/layers.rs
@@ -34,6 +34,7 @@ fn spawn(mut commands: Commands, mut materials: ResMut<Assets<ColorMaterial>>) {
         .insert(RigidBody::Static)
         .insert(CollisionShape::Cuboid {
             half_extends: size.extend(0.0) / 2.0,
+            border_radius: None,
         });
 
     // ANCHOR: layer-component-world
@@ -56,6 +57,7 @@ fn spawn(mut commands: Commands, mut materials: ResMut<Assets<ColorMaterial>>) {
         .insert(RigidBody::Dynamic)
         .insert(CollisionShape::Cuboid {
             half_extends: size.extend(0.0) / 2.0,
+            border_radius: None,
         });
 
     // ANCHOR: layer-component-player

--- a/examples/quickstart.rs
+++ b/examples/quickstart.rs
@@ -32,5 +32,6 @@ fn spawn(mut commands: Commands, mut materials: ResMut<Assets<ColorMaterial>>) {
         .insert(CollisionShape::Cuboid {
             // let the size be consistent with our sprite
             half_extends: size.extend(0.0) / 2.0,
+            border_radius: None,
         });
 }

--- a/examples/ray_casting.rs
+++ b/examples/ray_casting.rs
@@ -50,6 +50,7 @@ fn setup(mut commands: Commands, mut materials: ResMut<Assets<ColorMaterial>>) {
             .insert(RigidBody::Static)
             .insert(CollisionShape::Cuboid {
                 half_extends: size.extend(0.0) / 2.0,
+                border_radius: None,
             });
     }
 
@@ -83,6 +84,7 @@ fn setup(mut commands: Commands, mut materials: ResMut<Assets<ColorMaterial>>) {
         .insert(RigidBody::Static)
         .insert(CollisionShape::Cuboid {
             half_extends: Vec3::new(50., 50., 0.),
+            border_radius: None,
         })
         .insert(ShapeCastIgnored);
 }
@@ -153,6 +155,7 @@ fn shape_cast_from_center(
 
     let shape = CollisionShape::Cuboid {
         half_extends: shape_size.extend(0.) / 2.,
+        border_radius: None,
     };
 
     // Cast a ray from the center of the world, to the targeter.

--- a/rapier/src/pipeline.rs
+++ b/rapier/src/pipeline.rs
@@ -734,6 +734,7 @@ mod tests {
             commands.spawn_bundle((
                 CollisionShape::Cuboid {
                     half_extends: Vec3::new(10., 10., 10.),
+                    border_radius: None,
                 },
                 RigidBody::Static,
                 Transform::from_xyz(0., 100., 0.),
@@ -834,6 +835,7 @@ mod tests {
             let result = physics_world.shape_cast(
                 &CollisionShape::Cuboid {
                     half_extends: Vec3::new(10., 10., 10.),
+                    border_radius: None,
                 },
                 Vec3::default(),
                 Quat::default(),
@@ -880,6 +882,7 @@ mod tests {
             let result = physics_world.shape_cast(
                 &CollisionShape::Cuboid {
                     half_extends: Vec3::new(10., 10., 10.),
+                    border_radius: None,
                 },
                 Vec3::default(),
                 Quat::default(),

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -1,4 +1,4 @@
-#![cfg(any(feature = "2d", feature = "3d"))]
+#![cfg(any(dim2, dim3))]
 
 use rstest::rstest;
 


### PR DESCRIPTION
I needed rounded convex hulls for my project so here it is! I also added rounded cuboids because I _might_ need them and because they were easy.

I implemented debug rendering for rounded cubes and that works perfectly, but it's not worth my time currently to implement debug rendering for rounded convex hulls. I don't quite know how to do the math to make that one work right. As an interim solution, I simply rendered circles at each of the convex hull's points with hulls border radius. This at least gives an impression of the effect that the border radius has, even if it is not fully accurate.

![image](https://user-images.githubusercontent.com/25393315/122993079-7f43a380-d36c-11eb-9dc2-bee26b99131d.png)

Let me know if there are any problems!