### PR TITLE
Use Separate Cargo Features for Debug 2D and 3D

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,8 +74,8 @@ jobs:
         feature-set:
           - "2d"
           - "3d"
-          - "2d, debug"
-          - "3d, debug"
+          - "debug-2d"
+          - "2d, debug-2d"
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,7 +101,7 @@ jobs:
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libudev-dev libasound2-dev
 
       - name: Run tests
-        run: cargo test --workspace --no-default-features --features "${{ matrix.feature-set }}"
+        run: cargo test --workspace --features "${{ matrix.feature-set }}"
 
   ignored-tests:
     runs-on: ubuntu-latest
@@ -133,7 +133,7 @@ jobs:
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libudev-dev libasound2-dev
 
       - name: Run ignored tests
-        run: cargo test --workspace --features "debug" -- --ignored
+        run: cargo test --workspace --features "2d,debug-2d" -- --ignored
 
   doc:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,10 @@ keywords = ["game", "gamedev", "physics", "collision", "bevy"]
 categories = ["game-development", "simulation"]
 
 [features]
-default = ["3d"]
+default = []
 2d = ["heron_rapier/2d"]
 3d = ["heron_rapier/3d"]
-debug-2d = ["2d", "debug", "heron_debug/2d"]
-debug = ["heron_debug"]
+debug-2d = ["2d", "heron_debug/2d"]
 
 [dependencies]
 heron_core = { version = "^0.8.0", path = "core" }
@@ -30,6 +29,9 @@ bevy = { version = "^0.5.0", default-features = false }
 bevy = "0.5"
 skeptic = "0.13"
 rstest = "0.7"
+
+[build-dependencies]
+cfg_aliases = "0.1.1"
 
 [[example]]
 name = "demo"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,7 @@ categories = ["game-development", "simulation"]
 default = ["3d"]
 2d = ["heron_rapier/2d"]
 3d = ["heron_rapier/3d"]
-debug-2d = ["heron_debug/2d", "debug"]
-debug-3d = ["heron_debug/3d", "debug"]
+debug-2d = ["2d", "debug", "heron_debug/2d"]
 debug = ["heron_debug"]
 
 [dependencies]
@@ -38,7 +37,7 @@ required-features = ["2d"]
 
 [[example]]
 name = "debug"
-required-features = ["2d", "debug-2d"]
+required-features = ["debug-2d"]
 
 [[example]]
 name = "quickstart"
@@ -46,7 +45,7 @@ required-features = ["2d"]
 
 [[example]]
 name = "collision_shapes_in_child_entity"
-required-features = ["2d", "debug-2d"]
+required-features = ["debug-2d"]
 
 [[example]]
 name = "layers"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,10 @@ categories = ["game-development", "simulation"]
 
 [features]
 default = ["3d"]
-2d = ["heron_rapier/2d", "heron_debug/2d"]
-3d = ["heron_rapier/3d", "heron_debug/3d"]
+2d = ["heron_rapier/2d"]
+3d = ["heron_rapier/3d"]
+debug-2d = ["heron_debug/2d", "debug"]
+debug-3d = ["heron_debug/3d", "debug"]
 debug = ["heron_debug"]
 
 [dependencies]
@@ -36,7 +38,7 @@ required-features = ["2d"]
 
 [[example]]
 name = "debug"
-required-features = ["2d", "debug"]
+required-features = ["2d", "debug-2d"]
 
 [[example]]
 name = "quickstart"
@@ -44,7 +46,7 @@ required-features = ["2d"]
 
 [[example]]
 name = "collision_shapes_in_child_entity"
-required-features = ["2d", "debug"]
+required-features = ["2d", "debug-2d"]
 
 [[example]]
 name = "layers"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,10 @@
+fn main() {
+    cfg_aliases::cfg_aliases! {
+        // 2D feature is only enabled if 3D is not enabled
+        dim2: { all(feature = "2d", not(feature = "3d")) },
+        // 3D feature takes precedence over 2D feature
+        dim3: { all(feature = "3d") },
+        // debug-3d doesn't exist yet, but include it for when it does
+        debug: { any(feature = "debug-2d", feature = "debug-3d") }
+    }
+}

--- a/rapier/Cargo.toml
+++ b/rapier/Cargo.toml
@@ -23,3 +23,6 @@ crossbeam = "^0.8.0"
 [dev-dependencies]
 bevy = { version = "0.5", default-features = false }
 rstest = "0.7"
+
+[build-dependencies]
+cfg_aliases = "0.1.1"

--- a/rapier/build.rs
+++ b/rapier/build.rs
@@ -1,0 +1,8 @@
+fn main() {
+    cfg_aliases::cfg_aliases! {
+        // 2D feature is only enabled if 3D is not enabled
+        dim2: { all(feature = "2d", not(feature = "3d")) },
+        // 3D feature takes precedence over 2D feature
+        dim3: { all(feature = "3d") }
+    }
+}

--- a/rapier/src/acceleration.rs
+++ b/rapier/src/acceleration.rs
@@ -26,11 +26,11 @@ fn update_acceleration(body: &mut RigidBody, acceleration: &Acceleration) {
     let linear_acceleration: Vector<Real> = acceleration.linear.into_rapier();
     let angular_acceleration: AngVector<f32> = acceleration.angular.into_rapier();
     let inertia = {
-        #[cfg(feature = "3d")]
+        #[cfg(dim3)]
         {
             body.mass_properties().reconstruct_inertia_matrix()
         }
-        #[cfg(feature = "2d")]
+        #[cfg(dim2)]
         {
             let val = body.mass_properties().inv_principal_inertia_sqrt;
             if val == 0.0 {

--- a/rapier/src/body.rs
+++ b/rapier/src/body.rs
@@ -120,7 +120,7 @@ pub(crate) fn remove_invalids_after_component_changed(
     }
 }
 
-#[allow(clippy::filter_map)]
+#[allow(clippy::manual_filter_map)]
 fn remove_collider_handles(
     commands: &mut Commands<'_>,
     bodies: &RigidBodySet,

--- a/rapier/src/body.rs
+++ b/rapier/src/body.rs
@@ -41,22 +41,22 @@ pub(crate) fn create(
             allow_z,
         }) = rotation_constraints.copied()
         {
-            #[cfg(feature = "2d")]
+            #[cfg(dim2)]
             if !allow_z {
                 builder = builder.lock_rotations();
             }
-            #[cfg(feature = "3d")]
+            #[cfg(dim3)]
             {
                 builder = builder.restrict_rotations(allow_x, allow_y, allow_z);
             }
         }
 
         if let Some(v) = velocity {
-            #[cfg(feature = "2d")]
+            #[cfg(dim2)]
             {
                 builder = builder.linvel(v.linear.x, v.linear.y);
             }
-            #[cfg(feature = "3d")]
+            #[cfg(dim3)]
             {
                 builder = builder.linvel(v.linear.x, v.linear.y, v.linear.z);
             }

--- a/rapier/src/convert.rs
+++ b/rapier/src/convert.rs
@@ -183,14 +183,14 @@ impl IntoBevy<CollisionLayers> for InteractionGroups {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "3d")]
+    #[cfg(dim3)]
     use std::f32::consts::PI;
 
     use bevy::math::{Quat, Vec3};
 
     use super::*;
 
-    #[cfg(feature = "2d")]
+    #[cfg(dim2)]
     mod angle2d {
         use rstest::rstest;
 
@@ -228,12 +228,12 @@ mod tests {
             assert_eq!(translation.x, result.translation.x);
             assert_eq!(translation.y, result.translation.y);
 
-            #[cfg(feature = "3d")]
+            #[cfg(dim3)]
             assert_eq!(translation.z, result.translation.z);
         }
 
         #[test]
-        #[cfg(feature = "3d")]
+        #[cfg(dim3)]
         fn set_rotation() {
             let angle = PI / 2.0;
             let axis = Vec3::new(1.0, 2.0, 3.0);

--- a/rapier/src/lib.rs
+++ b/rapier/src/lib.rs
@@ -1,16 +1,13 @@
 #![deny(future_incompatible, nonstandard_style)]
 #![warn(missing_docs, rust_2018_idioms, clippy::pedantic)]
 #![allow(clippy::needless_pass_by_value, clippy::type_complexity)]
-#![cfg(all(
-    any(feature = "2d", feature = "3d"),
-    not(all(feature = "2d", feature = "3d")),
-))]
+#![cfg(any(dim2, dim3))]
 
 //! Physics behavior for Heron, using [rapier](https://rapier.rs/)
 
-#[cfg(feature = "2d")]
+#[cfg(dim2)]
 pub extern crate rapier2d as rapier;
-#[cfg(feature = "3d")]
+#[cfg(dim3)]
 pub extern crate rapier3d as rapier;
 
 use bevy::prelude::*;

--- a/rapier/src/velocity.rs
+++ b/rapier/src/velocity.rs
@@ -52,12 +52,12 @@ pub(crate) fn update_velocity_component(
         if let Some(body) = bodies.get(*handle).filter(|it| it.is_dynamic()) {
             velocity.linear = (*body.linvel()).into_bevy();
 
-            #[cfg(feature = "2d")]
+            #[cfg(dim2)]
             {
                 velocity.angular = heron_core::AxisAngle::from(bevy::math::Vec3::Z * body.angvel());
             }
 
-            #[cfg(feature = "3d")]
+            #[cfg(dim3)]
             {
                 velocity.angular = (*body.angvel()).into_bevy().into();
             }

--- a/rapier/tests/acceleration.rs
+++ b/rapier/tests/acceleration.rs
@@ -1,8 +1,4 @@
-#![cfg(all(
-    any(feature = "2d", feature = "3d"),
-    not(all(feature = "2d", feature = "3d")),
-))]
-
+#![cfg(any(dim2, dim3))]
 use bevy::core::CorePlugin;
 use bevy::prelude::*;
 use bevy::prelude::{GlobalTransform, Transform};
@@ -10,7 +6,7 @@ use bevy::reflect::TypeRegistryArc;
 
 use heron_core::{Acceleration, AxisAngle, CollisionShape, PhysicsSteps, RigidBody};
 use heron_rapier::convert::IntoBevy;
-#[cfg(feature = "3d")]
+#[cfg(dim3)]
 use heron_rapier::rapier::math::Vector;
 use heron_rapier::{rapier::dynamics::RigidBodySet, RapierPlugin};
 use std::time::Duration;
@@ -29,9 +25,9 @@ fn test_app() -> App {
 fn body_is_created_with_acceleration() {
     let mut app = test_app();
 
-    #[cfg(feature = "3d")]
+    #[cfg(dim3)]
     let linear = Vec3::new(1.0, 2.0, 3.0);
-    #[cfg(feature = "2d")]
+    #[cfg(dim2)]
     let linear = Vec3::new(1.0, 2.0, 0.0);
 
     let angular = AxisAngle::new(Vec3::Z, 1.0);
@@ -88,9 +84,9 @@ fn acceleration_may_be_added_after_creating_the_body() {
 
     app.update();
 
-    #[cfg(feature = "3d")]
+    #[cfg(dim3)]
     let linear = Vec3::new(1.0, 2.0, 3.0);
-    #[cfg(feature = "2d")]
+    #[cfg(dim2)]
     let linear = Vec3::new(1.0, 2.0, 0.0);
 
     let angular = AxisAngle::new(Vec3::Z, 2.0);
@@ -109,12 +105,12 @@ fn acceleration_may_be_added_after_creating_the_body() {
     assert_eq_angular(body.angvel(), angular);
 }
 
-#[cfg(feature = "3d")]
+#[cfg(dim3)]
 fn assert_eq_angular(actual: &Vector<f32>, expected: AxisAngle) {
     assert_eq!(actual.into_bevy(), expected.into());
 }
 
-#[cfg(feature = "2d")]
+#[cfg(dim2)]
 fn assert_eq_angular(expected: f32, actual: AxisAngle) {
     assert!(
         (expected - actual.angle()).abs() < 0.00001,

--- a/rapier/tests/bodies.rs
+++ b/rapier/tests/bodies.rs
@@ -1,8 +1,4 @@
-#![cfg(all(
-    any(feature = "2d", feature = "3d"),
-    not(all(feature = "2d", feature = "3d")),
-))]
-
+#![cfg(any(dim2, dim3))]
 use std::f32::consts::PI;
 use std::ops::DerefMut;
 use std::time::Duration;

--- a/rapier/tests/body_types.rs
+++ b/rapier/tests/body_types.rs
@@ -1,8 +1,4 @@
-#![cfg(all(
-    any(feature = "2d", feature = "3d"),
-    not(all(feature = "2d", feature = "3d")),
-))]
-
+#![cfg(any(dim2, dim3))]
 use std::time::Duration;
 
 use bevy::core::CorePlugin;

--- a/rapier/tests/children_collision_shapes.rs
+++ b/rapier/tests/children_collision_shapes.rs
@@ -1,8 +1,4 @@
-#![cfg(all(
-    any(feature = "2d", feature = "3d"),
-    not(all(feature = "2d", feature = "3d")),
-))]
-
+#![cfg(any(dim2, dim3))]
 use std::time::Duration;
 
 use bevy::core::CorePlugin;
@@ -64,12 +60,12 @@ fn can_use_child_entity_for_the_collision_shape() {
 
     let (actual_translation, actual_rotation) = collider.position_wrt_parent().into_bevy();
 
-    #[cfg(feature = "2d")]
+    #[cfg(dim2)]
     assert_eq!(
         actual_translation,
         Vec3::new(translation.x, translation.y, 0.0)
     );
-    #[cfg(feature = "3d")]
+    #[cfg(dim3)]
     assert_eq!(actual_translation, translation);
 
     assert!((actual_rotation.x - rotation.x).abs() < 0.00001);
@@ -110,12 +106,12 @@ fn can_change_the_position_of_a_shape_inserted_in_child_entity() {
 
     let (actual_translation, _) = collider.position_wrt_parent().into_bevy();
 
-    #[cfg(feature = "2d")]
+    #[cfg(dim2)]
     assert_eq!(
         actual_translation,
         Vec3::new(translation.x, translation.y, 0.0)
     );
-    #[cfg(feature = "3d")]
+    #[cfg(dim3)]
     assert_eq!(actual_translation, translation);
 }
 

--- a/rapier/tests/constraints.rs
+++ b/rapier/tests/constraints.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "2d")]
+#![cfg(all(feature = "2d", not(feature = "3d")))]
 
 use std::time::Duration;
 

--- a/rapier/tests/density.rs
+++ b/rapier/tests/density.rs
@@ -1,8 +1,4 @@
-#![cfg(all(
-    any(feature = "2d", feature = "3d"),
-    not(all(feature = "2d", feature = "3d")),
-))]
-
+#![cfg(any(dim2, dim3))]
 use std::time::Duration;
 
 use bevy::core::CorePlugin;

--- a/rapier/tests/events.rs
+++ b/rapier/tests/events.rs
@@ -1,8 +1,4 @@
-#![cfg(all(
-    any(feature = "2d", feature = "3d"),
-    not(all(feature = "2d", feature = "3d")),
-))]
-
+#![cfg(any(dim2, dim3))]
 use bevy::app::{Events, ManualEventReader};
 use bevy::core::CorePlugin;
 use bevy::prelude::*;

--- a/rapier/tests/friction.rs
+++ b/rapier/tests/friction.rs
@@ -1,8 +1,4 @@
-#![cfg(all(
-    any(feature = "2d", feature = "3d"),
-    not(all(feature = "2d", feature = "3d")),
-))]
-
+#![cfg(any(dim2, dim3))]
 use std::time::Duration;
 
 use bevy::core::CorePlugin;

--- a/rapier/tests/layers.rs
+++ b/rapier/tests/layers.rs
@@ -1,8 +1,4 @@
-#![cfg(all(
-    any(feature = "2d", feature = "3d"),
-    not(all(feature = "2d", feature = "3d")),
-))]
-
+#![cfg(any(dim2, dim3))]
 use bevy::core::CorePlugin;
 use bevy::prelude::*;
 use bevy::reflect::TypeRegistryArc;

--- a/rapier/tests/resources.rs
+++ b/rapier/tests/resources.rs
@@ -1,8 +1,4 @@
-#![cfg(all(
-    any(feature = "2d", feature = "3d"),
-    not(all(feature = "2d", feature = "3d")),
-))]
-
+#![cfg(any(dim2, dim3))]
 use bevy::app::prelude::*;
 use bevy::core::CorePlugin;
 use bevy::math::prelude::*;

--- a/rapier/tests/restitution.rs
+++ b/rapier/tests/restitution.rs
@@ -1,8 +1,4 @@
-#![cfg(all(
-    any(feature = "2d", feature = "3d"),
-    not(all(feature = "2d", feature = "3d")),
-))]
-
+#![cfg(any(dim2, dim3))]
 use bevy::core::CorePlugin;
 use bevy::prelude::*;
 use bevy::reflect::TypeRegistryArc;

--- a/rapier/tests/sensor_shape.rs
+++ b/rapier/tests/sensor_shape.rs
@@ -1,8 +1,4 @@
-#![cfg(all(
-    any(feature = "2d", feature = "3d"),
-    not(all(feature = "2d", feature = "3d")),
-))]
-
+#![cfg(any(dim2, dim3))]
 use std::time::Duration;
 
 use bevy::core::CorePlugin;

--- a/rapier/tests/velocity.rs
+++ b/rapier/tests/velocity.rs
@@ -1,8 +1,4 @@
-#![cfg(all(
-    any(feature = "2d", feature = "3d"),
-    not(all(feature = "2d", feature = "3d")),
-))]
-
+#![cfg(any(dim2, dim3))]
 use std::f32::consts::PI;
 use std::time::Duration;
 
@@ -56,13 +52,13 @@ fn body_is_created_with_velocity() {
     assert_eq!(linear.x, actual_linear.x);
     assert_eq!(linear.y, actual_linear.y);
 
-    #[cfg(feature = "3d")]
+    #[cfg(dim3)]
     assert_eq!(linear.z, actual_linear.z);
 
-    #[cfg(feature = "3d")]
+    #[cfg(dim3)]
     assert_eq!(angular, (*body.angvel()).into_bevy().into());
 
-    #[cfg(feature = "2d")]
+    #[cfg(dim2)]
     assert_eq!(angular.angle(), body.angvel());
 }
 
@@ -100,13 +96,13 @@ fn velocity_may_be_added_after_creating_the_body() {
     assert_eq!(linear.x, actual_linear.x);
     assert_eq!(linear.y, actual_linear.y);
 
-    #[cfg(feature = "3d")]
+    #[cfg(dim3)]
     assert_eq!(linear.z, actual_linear.z);
 
-    #[cfg(feature = "2d")]
+    #[cfg(dim2)]
     assert_eq!(angular.angle(), body.angvel());
 
-    #[cfg(feature = "3d")]
+    #[cfg(dim3)]
     assert_eq!(angular, (*body.angvel()).into_bevy().into());
 }
 
@@ -138,13 +134,13 @@ fn velocity_is_updated_to_reflect_rapier_world() {
     assert_eq!(velocity.linear.x, linear.x);
     assert_eq!(velocity.linear.y, linear.y);
 
-    #[cfg(feature = "3d")]
+    #[cfg(dim3)]
     assert_eq!(velocity.linear.z, linear.z);
 
-    #[cfg(feature = "3d")]
+    #[cfg(dim3)]
     assert_eq!(angular, velocity.angular.into());
 
-    #[cfg(feature = "2d")]
+    #[cfg(dim2)]
     assert!((angular.angle() - velocity.angular.angle()).abs() < 0.001);
 }
 
@@ -181,10 +177,10 @@ fn velocity_can_move_kinematic_bodies(#[case] body_type: Option<RigidBody>) {
         ..
     } = *app.world.get::<Transform>(entity).unwrap();
 
-    #[cfg(feature = "3d")]
+    #[cfg(dim3)]
     assert_eq!(actual_translation, translation);
 
-    #[cfg(feature = "2d")]
+    #[cfg(dim2)]
     assert_eq!(actual_translation.truncate(), translation.truncate());
 
     let (axis, angle) = rotation.to_axis_angle();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,7 @@
 #![deny(future_incompatible, nonstandard_style)]
 #![warn(missing_docs, rust_2018_idioms, clippy::pedantic)]
 #![allow(clippy::needless_pass_by_value, clippy::needless_doctest_main)]
-#![cfg(all(
-    any(feature = "2d", feature = "3d"),
-    not(all(feature = "2d", feature = "3d")),
-))]
+#![cfg(any(dim2, dim3))]
 //! An ergonomic physics API for 2d and 3d [bevy] games. (powered by [rapier])
 //!
 //! [bevy]: https://bevyengine.org
@@ -134,7 +131,7 @@ pub mod prelude {
 #[must_use]
 #[derive(Debug, Copy, Clone, Default)]
 pub struct PhysicsPlugin {
-    #[cfg(feature = "debug")]
+    #[cfg(debug)]
     debug: heron_debug::DebugPlugin,
 }
 
@@ -142,7 +139,7 @@ impl Plugin for PhysicsPlugin {
     fn build(&self, app: &mut AppBuilder) {
         app.add_plugin(RapierPlugin);
 
-        #[cfg(feature = "debug")]
+        #[cfg(debug)]
         app.add_plugin(self.debug);
     }
 }

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -1,3 +1,5 @@
+#![cfg(any(feature = "2d", feature = "3d"))]
+
 use rstest::rstest;
 
 use heron_core::PhysicsLayer;


### PR DESCRIPTION
Currently, the heron crate doesn't expose anything unless either the 2D or 3D features are enabled, but enabling either of those features also enables the debug renderer. This makes it impossible to use heron without enabling the debug rendering crates.

My projects use Bevy Retrograde, which uses a custom renderer on top of Bevy that won't compile when bevy's rendering features are enabled. Because the debug crates require Bevy's rendering features, there's no combination of features under which I can compile heron for use in Bevy Retrograde.

This change makes it required to pass in the `debug-2d` or `debug-3d` features in order to actually include the `heron_debug`. This allows me to run my project without including bevy's rendering features.

I'm not sure this is the best way to do it and I'm totally open to any other options, as long as there is some way to compile without  needing `heron_debug`.