### PR TITLE
Preserve 2D Z Translation

### DIFF
--- a/rapier/src/body.rs
+++ b/rapier/src/body.rs
@@ -179,27 +179,23 @@ pub(crate) fn update_bevy_transform(
             Some(body) => body,
         };
 
-        let (translation, rotation) = body.position().into_bevy();
+        let (mut translation, rotation) = body.position().into_bevy();
+
+        #[cfg(dim2)]
+        {
+            // In 2D, preserve the transform `z` component that may have been set by the user
+            translation.z = global.translation.z;
+        }
 
         if translation == global.translation && rotation == global.rotation {
             continue;
         }
 
         if let Some(local) = &mut local {
-            #[cfg(dim2)]
-            let previous_local_z = local.translation.z;
-
             if local.translation == global.translation {
                 local.translation = translation;
             } else {
                 local.translation = translation - (global.translation - local.translation);
-            }
-
-            // In 2D, preserve the transform `z` component that may have been set by the user and
-            // would be overridden by the simulation value
-            #[cfg(dim2)]
-            {
-                local.translation.z = previous_local_z;
             }
 
             if local.rotation == global.rotation {
@@ -210,18 +206,7 @@ pub(crate) fn update_bevy_transform(
             }
         }
 
-        #[cfg(dim2)]
-        let previous_local_z = global.translation.z;
-
         global.translation = translation;
-
-        // In 2D, preserve the transform `z` component that may have been set by the user and
-        // would be overridden by the simulation value
-        #[cfg(dim2)]
-        {
-            global.translation.z = previous_local_z;
-        }
-
         global.rotation = rotation;
     }
 }

--- a/rapier/src/body.rs
+++ b/rapier/src/body.rs
@@ -179,6 +179,9 @@ pub(crate) fn update_bevy_transform(
             Some(body) => body,
         };
 
+        #[cfg(dim3)]
+        let (translation, rotation) = body.position().into_bevy();
+        #[cfg(dim2)]
         let (mut translation, rotation) = body.position().into_bevy();
 
         #[cfg(dim2)]

--- a/rapier/src/body.rs
+++ b/rapier/src/body.rs
@@ -186,10 +186,20 @@ pub(crate) fn update_bevy_transform(
         }
 
         if let Some(local) = &mut local {
+            #[cfg(dim2)]
+            let previous_local_z = local.translation.z;
+
             if local.translation == global.translation {
                 local.translation = translation;
             } else {
                 local.translation = translation - (global.translation - local.translation);
+            }
+
+            // In 2D, preserve the transform `z` component that may have been set by the user and
+            // would be overridden by the simulation value
+            #[cfg(dim2)]
+            {
+                local.translation.z = previous_local_z;
             }
 
             if local.rotation == global.rotation {
@@ -200,7 +210,18 @@ pub(crate) fn update_bevy_transform(
             }
         }
 
+        #[cfg(dim2)]
+        let previous_local_z = global.translation.z;
+
         global.translation = translation;
+
+        // In 2D, preserve the transform `z` component that may have been set by the user and
+        // would be overridden by the simulation value
+        #[cfg(dim2)]
+        {
+            global.translation.z = previous_local_z;
+        }
+
         global.rotation = rotation;
     }
 }

--- a/rapier/tests/velocity.rs
+++ b/rapier/tests/velocity.rs
@@ -1,4 +1,5 @@
 #![cfg(any(dim2, dim3))]
+
 use std::f32::consts::PI;
 use std::time::Duration;
 
@@ -188,4 +189,32 @@ fn velocity_can_move_kinematic_bodies(#[case] body_type: Option<RigidBody>) {
 
     assert!(actual_axis.angle_between(axis) < 0.001);
     assert!((actual_angle - angle).abs() < 0.001);
+}
+
+#[test]
+#[cfg(dim2)]
+fn z_components_is_preserved() {
+    let mut app = test_app();
+    let translation = Vec3::new(1.0, 2.0, 3.0);
+
+    let entity = app
+        .world
+        .spawn()
+        .insert_bundle((
+            RigidBody::Dynamic,
+            CollisionShape::Sphere { radius: 2.0 },
+            Transform::from_translation(Vec3::splat(5.0)),
+            GlobalTransform::default(),
+            Velocity::from(translation),
+        ))
+        .id();
+
+    app.update();
+
+    let Transform {
+        translation: actual_translation,
+        ..
+    } = *app.world.get::<Transform>(entity).unwrap();
+
+    assert_eq!(5.0, actual_translation.z);
 }


### PR DESCRIPTION
When adding a rigid body to a 2D object, the Bevy transform update system will reset any translation z value that I have set on the 2D object to 0. This update perserves the 2D Z translation set by the user so that the 2D layers will still work correctly after adding a rigid body to them.

Depends on #118.