### PR TITLE
Compound Collision Shape

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -163,6 +163,20 @@ pub enum CollisionShape {
         /// inner `Vec`, any other element will be ignored.
         heights: Vec<Vec<f32>>,
     },
+
+    /// A compound shape made out of a vector of shapes and their relative transforms
+    Compound(Vec<CompoundSubShape>),
+}
+
+/// A sub-shape inside of a a [`CollisionShape::Compound`]
+#[derive(Debug, Clone)]
+pub struct CompoundSubShape {
+    /// The relative translation of this shape relative to the origin of the compound shape
+    pub translation: Vec3,
+    /// Rotation of the this shape relative to the compound shape
+    pub rotation: Quat,
+    /// The shape of the sub-shape in the compound shape
+    pub shape: CollisionShape,
 }
 
 impl Default for CollisionShape {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -130,12 +130,22 @@ pub enum CollisionShape {
         ///
         /// In 2d the `z` axis is ignored
         half_extends: Vec3,
+        /// An optional border radius that will be used to round the corners of the cuboid
+        ///
+        /// This radius refers to how much to _add_ to the existing size of the cuboid, creating an
+        /// extra buffer around the un-rounded extent.
+        border_radius: Option<f32>,
     },
 
     /// A convex polygon/polyhedron shape
     ConvexHull {
         /// A vector of points describing the convex hull
         points: Vec<Vec3>,
+        /// An optional border radius that will be used to round the corners of the convex hull
+        ///
+        /// This radius refers to how much to _add_ to the existing size of the hull, creating an
+        /// extra buffer around the un-rounded mesh.
+        border_radius: Option<f32>,
     },
 
     /// A shape defined by the height of points.

--- a/debug/Cargo.toml
+++ b/debug/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/jcornaz/heron/"
 
 [features]
 default = []
-2d = ["heron_rapier/2d", "bevy_prototype_lyon"]
+2d = ["heron_rapier/2d", "bevy_prototype_lyon", "lyon_path"]
 3d = ["heron_rapier/3d"]
 
 [dependencies]
@@ -17,4 +17,5 @@ heron_core = { version = "^0.8.0", path = "../core" }
 heron_rapier = { version = "^0.8.0", path = "../rapier" }
 bevy = { version = "^0.5.0", default-features = false, features = ["render"] }
 bevy_prototype_lyon = { version = "0.3.0", optional = true }
+lyon_path = { version = "0.17.4", optional = true }
 fnv = "^1.0"

--- a/examples/collision_shapes_in_child_entity.rs
+++ b/examples/collision_shapes_in_child_entity.rs
@@ -28,6 +28,7 @@ fn spawn(mut commands: Commands) {
             children.spawn_bundle((
                 CollisionShape::Cuboid {
                     half_extends: Vec3::new(15.0, 15.0, 0.0),
+                    border_radius: None,
                 },
                 Transform::default(),
                 GlobalTransform::default(),
@@ -37,6 +38,7 @@ fn spawn(mut commands: Commands) {
             children.spawn_bundle((
                 CollisionShape::Cuboid {
                     half_extends: Vec3::new(50.0, 50.0, 0.0),
+                    border_radius: None,
                 },
                 Transform::from_translation(Vec3::X * 100.0),
                 GlobalTransform::default(),
@@ -70,6 +72,7 @@ fn spawn_ground_and_camera(mut commands: Commands) {
         RigidBody::Static,
         CollisionShape::Cuboid {
             half_extends: Vec2::new(1500.0, 50.0).extend(0.0) / 2.0,
+            border_radius: None,
         },
     ));
 }

--- a/examples/debug.rs
+++ b/examples/debug.rs
@@ -27,6 +27,7 @@ fn spawn(mut commands: Commands) {
         ))
         .insert(CollisionShape::Cuboid {
             half_extends: Vec2::new(50.0, 50.0).extend(0.0),
+            border_radius: None,
         })
         .insert(RigidBody::Static);
 
@@ -54,6 +55,7 @@ fn spawn(mut commands: Commands) {
                 Vec3::new(50.0, 0.0, 0.0),
                 Vec3::new(-50.0, 0.0, 0.0),
             ],
+            border_radius: None,
         })
         .insert(RigidBody::Static);
 

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -32,6 +32,7 @@ fn spawn(mut commands: Commands, mut materials: ResMut<Assets<ColorMaterial>>) {
         // Attach a collision shape
         .insert(CollisionShape::Cuboid {
             half_extends: size.extend(0.0) / 2.0,
+            border_radius: None,
         })
         // Define restitution (so that it bounces)
         .insert(PhysicMaterial {
@@ -54,6 +55,7 @@ fn spawn(mut commands: Commands, mut materials: ResMut<Assets<ColorMaterial>>) {
         // Attach a collision shape
         .insert(CollisionShape::Cuboid {
             half_extends: size.extend(0.0) / 2.0,
+            border_radius: None,
         })
         // Add an initial velocity. (it is also possible to read/mutate this component later)
         .insert(Velocity::from(Vec2::X * 300.0).with_angular(AxisAngle::new(Vec3::Z, -PI)))

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -85,6 +85,7 @@ fn spawn_player(mut commands: Commands, mut materials: ResMut<Assets<ColorMateri
         .insert(RigidBody::Dynamic)
         .insert(CollisionShape::Cuboid {
             half_extends: size.extend(0.0) / 2.0,
+            border_radius: None,
         })
         .insert(Velocity::default())
         .insert(CollisionLayers::new(Layer::Player, Layer::Enemy));
@@ -102,6 +103,7 @@ fn spawn_enemy(mut commands: Commands, mut materials: ResMut<Assets<ColorMateria
         .insert(RigidBody::Static)
         .insert(CollisionShape::Cuboid {
             half_extends: size.extend(0.0) / 2.0,
+            border_radius: None,
         })
         .insert(CollisionLayers::new(Layer::Enemy, Layer::Player));
 }

--- a/examples/layers.rs
+++ b/examples/layers.rs
@@ -34,6 +34,7 @@ fn spawn(mut commands: Commands, mut materials: ResMut<Assets<ColorMaterial>>) {
         .insert(RigidBody::Static)
         .insert(CollisionShape::Cuboid {
             half_extends: size.extend(0.0) / 2.0,
+            border_radius: None,
         });
 
     // ANCHOR: layer-component-world
@@ -56,6 +57,7 @@ fn spawn(mut commands: Commands, mut materials: ResMut<Assets<ColorMaterial>>) {
         .insert(RigidBody::Dynamic)
         .insert(CollisionShape::Cuboid {
             half_extends: size.extend(0.0) / 2.0,
+            border_radius: None,
         });
 
     // ANCHOR: layer-component-player

--- a/examples/quickstart.rs
+++ b/examples/quickstart.rs
@@ -32,5 +32,6 @@ fn spawn(mut commands: Commands, mut materials: ResMut<Assets<ColorMaterial>>) {
         .insert(CollisionShape::Cuboid {
             // let the size be consistent with our sprite
             half_extends: size.extend(0.0) / 2.0,
+            border_radius: None,
         });
 }

--- a/rapier/tests/bodies.rs
+++ b/rapier/tests/bodies.rs
@@ -77,7 +77,7 @@ fn creates_body_in_rapier_world() {
     #[cfg(dim3)]
     assert_eq!(actual_translation, translation);
 
-    #[cfg(feature = "2d")]
+    #[cfg(dim2)]
     assert_eq!(actual_translation.truncate(), translation.truncate());
 
     let (axis, angle) = rotation.to_axis_angle();
@@ -148,10 +148,10 @@ fn update_rapier_position() {
     let rigid_body = colliders.get(*app.world.get(entity).unwrap()).unwrap();
     let (actual_translation, actual_rotation) = rigid_body.position().into_bevy();
 
-    #[cfg(feature = "3d")]
+    #[cfg(dim3)]
     assert_eq!(actual_translation, translation);
 
-    #[cfg(feature = "2d")]
+    #[cfg(dim2)]
     assert_eq!(actual_translation.truncate(), translation.truncate());
 
     let (axis, angle) = rotation.to_axis_angle();

--- a/rapier/tests/constraints.rs
+++ b/rapier/tests/constraints.rs
@@ -1,4 +1,4 @@
-#![cfg(all(feature = "2d", not(feature = "3d")))]
+#![cfg(dim2)]
 
 use std::time::Duration;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,7 +133,7 @@ pub mod prelude {
     pub use crate::{
         ext::*, stage, Acceleration, AxisAngle, CollisionEvent, CollisionLayers, CollisionShape,
         Gravity, PhysicMaterial, PhysicsLayer, PhysicsPlugin, PhysicsSystem, PhysicsTime,
-        RigidBody, RotationConstraints, Velocity,
+        RigidBody, RotationConstraints, Velocity,CompoundSubShape
     };
 }
 

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -1,4 +1,4 @@
-#![cfg(any(feature = "2d", feature = "3d"))]
+#![cfg(any(dim2, dim3))]
 
 use rstest::rstest;
 


### PR DESCRIPTION
Depends on #117 .

This works, but the debug rendering doesn't render the object rotations yet. I'm going to make sure I can get my uses-case working before I implement that, I think, because I don't need it for testing.

Here's what it looks like to create a compound collision shape:

```rust
// ...
.insert(CollisionShape::Compound(vec![
            CompoundSubShape {
                translation: Vec3::new(-100., 100., 0.),
                rotation: Default::default(),
                shape: CollisionShape::ConvexHull {
                    points: vec![
                        Vec3::new(-20., -20., 0.),
                        Vec3::new(20., -20., 0.),
                        Vec3::new(20., 20., 0.),
                        Vec3::new(-20., 20., 0.),
                    ],
                    border_radius: Some(8.),
                },
            },
            CompoundSubShape {
                translation: Vec3::new(0., 0., 0.),
                rotation: Default::default(),
                shape: CollisionShape::Cuboid {
                    half_extends: Vec3::new(5., 5., 0.),
                    border_radius: None,
                },
            },
        ]))
// ...
```