### PR TITLE
Implement Variable Timestep Mode for PhysicsSteps

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -12,7 +12,7 @@ pub use events::{CollisionData, CollisionEvent};
 pub use gravity::Gravity;
 pub use layers::{CollisionLayers, PhysicsLayer};
 pub use physics_time::PhysicsTime;
-pub use step::PhysicsSteps;
+pub use step::{PhysicsStepDuration, PhysicsSteps};
 pub use velocity::{Acceleration, AxisAngle, Velocity};
 
 mod constraints;

--- a/rapier/src/velocity.rs
+++ b/rapier/src/velocity.rs
@@ -27,9 +27,13 @@ pub(crate) fn update_rapier_velocity(
 pub(crate) fn apply_velocity_to_kinematic_bodies(
     mut bodies: ResMut<'_, RigidBodySet>,
     physics_step: Res<'_, PhysicsSteps>,
+    bevy_time: Res<'_, bevy::core::Time>,
     query: Query<'_, (&RigidBodyHandle, &RigidBody, &Velocity)>,
 ) {
-    let delta_time = physics_step.duration().as_secs_f32();
+    let delta_time = physics_step
+        .duration()
+        .exact(bevy_time.delta())
+        .as_secs_f32();
     let kinematic_bodies = query
         .iter()
         .filter(|(_, body_type, _)| matches!(body_type, RigidBody::KinematicVelocityBased));


### PR DESCRIPTION
I'm not sure if I'm missing some caveats or something, but I like the variable timestep strategy because the simulation speed is stable regardless of the framerate. That way, even if some machines can only run at 30 fps, it won't cause a physics slowdown when the physics step is set to 58 fps to optimize for players who can run the game at 60 fps. Or even for players who's FPS might drop temporarily.