### PR TITLE
fix!: Compilation errors for 3d users

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - next-major
 
   pull_request:
     branches:
@@ -12,132 +11,76 @@ on:
 
 jobs:
   test:
-    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      RUSTFLAGS: "-D warnings"
 
     strategy:
       matrix:
-        os:
-          - ubuntu-latest
-          - windows-latest
         rust:
-          - stable
-          - nightly
+          - '1.53.0'
+        crate:
+          - '.'
+          - 'core'
+          - 'rapier'
+          - 'debug'
+          - 'macros'
 
-    runs-on: ${{ matrix.os }}
-    env:
-      RUSTFLAGS: "-D warnings"
+    defaults:
+      run:
+        working-directory: ${{ matrix.crate }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2.3.4
 
-      - name: Global cache
-        uses: actions/cache@v2.1.6
+      - name: Cache
+        uses: actions/cache@v2
         with:
           path: |
-            ~/.cargo
             ~/.rustup
-          key: cargo-${{ matrix.os }}-${{ matrix.rust }}-${{ hashFiles('**/Cargo.toml') }}
-          restore-keys: cargo-${{ matrix.os }}-${{ matrix.rust }}
+            ~/.cargo
+            ./target
+          key: build-${{ matrix.crate }}-${{ matrix.rust }}-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/*.rs') }}
+          restore-keys: |
+            build-${{ matrix.crate }}-${{ matrix.rust }}-${{ hashFiles('**/Cargo.toml') }}-
+            build-${{ matrix.crate }}-${{ matrix.rust }}-
 
       - name: Install rust toolchain
         uses: actions-rs/toolchain@v1.0.7
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
-          components: rustfmt, clippy
-
-      - name: Install linux dependencies
-        if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get update; sudo apt-get install --no-install-recommends libudev-dev libasound2-dev
-
-      - name: Format check
-        if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable'
-        run: cargo fmt --all -- --check
-
-      - name: Static analysis
-        if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable'
-        run: cargo clippy -- -Dwarnings
-
-      - name: Run tests with default features
-        run: cargo test --workspace
-
-  test-features:
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    env:
-      RUSTFLAGS: "-D warnings"
-
-    strategy:
-      matrix:
-        feature-set:
-          - "2d"
-          - "3d"
-          - "debug-2d"
-          - "2d, debug-2d"
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2.3.4
-
-      - name: Global cache
-        uses: actions/cache@v2.1.6
-        with:
-          path: |
-            ~/.cargo
-            ~/.rustup
-          key: cargo-ubuntu-latest-stable-${{ hashFiles('**/Cargo.toml') }}
-          restore-keys: cargo-ubuntu-latest-stable
-
-      - name: Install rust toolchain
-        uses: actions-rs/toolchain@v1.0.7
-        with:
           profile: minimal
-          toolchain: stable
-          override: true
-
-      - name: Install dependencies
-        run: sudo apt-get update; sudo apt-get install --no-install-recommends libudev-dev libasound2-dev
-
-      - name: Run tests
-        run: cargo test --workspace --features "${{ matrix.feature-set }}"
-
-  ignored-tests:
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    env:
-      RUSTFLAGS: "-D warnings"
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2.3.4
-
-      - name: Global cache
-        uses: actions/cache@v2.1.6
-        with:
-          path: |
-            ~/.cargo
-            ~/.rustup
-          key: cargo-ubuntu-latest-stable-${{ hashFiles('**/Cargo.toml') }}
-          restore-keys: cargo-ubuntu-latest-stable
-
-      - name: Install rust toolchain
-        uses: actions-rs/toolchain@v1.0.7
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
-      - name: Install dependencies
-        run: sudo apt-get update; sudo apt-get install --no-install-recommends libudev-dev libasound2-dev
 
       - name: Run ignored tests
-        run: cargo test --workspace --features "2d,debug-2d" -- --ignored
+        run: cargo test --all-features -- --ignored
 
-  doc:
+      - name: Test with all features
+        run: cargo test --all-features
+
+      - name: Test without any feature
+        run: cargo test --no-default-features
+
+      - name: Test with 2d feature
+        if: matrix.crate == 'rapier' || matrix.crate == 'debug' || matrix.crate == '.'
+        run: cargo test --no-default-features --features 2d
+
+      - name: Test with 3d feature
+        if: matrix.crate == 'rapier' || matrix.crate == 'debug' || matrix.crate == '.'
+        run: cargo test --no-default-features --features 3d
+
+      - name: Test with debug-2d feature
+        if: matrix.crate == '.'
+        run: cargo test --no-default-features --features debug-2d
+
+      - name: Test with default features
+        run: cargo test
+
+  code-style:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 15
     env:
       RUSTFLAGS: "-D warnings"
 
@@ -145,24 +88,55 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2.3.4
 
-      - name: Global cache
-        uses: actions/cache@v2.1.6
+      - name: Cache
+        uses: actions/cache@v2
         with:
           path: |
-            ~/.cargo
             ~/.rustup
-          key: cargo-ubuntu-latest-stable-${{ hashFiles('**/Cargo.toml') }}
-          restore-keys: cargo-ubuntu-latest-stable
+            ~/.cargo
+            ./target
+          key: code-style-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/*.rs') }}
+          restore-keys: code-style-${{ hashFiles('**/Cargo.toml') }}-
 
       - name: Install rust toolchain
         uses: actions-rs/toolchain@v1.0.7
         with:
-          profile: minimal
           toolchain: stable
           override: true
+          components: clippy, rustfmt
 
-      - name: Install dependencies
-        run: sudo apt-get update; sudo apt-get install --no-install-recommends libudev-dev libasound2-dev
+      - name: Format
+        run: cargo fmt -- --check
 
-      - name: Run ignored tests
+      - name: Clippy
+        run: cargo clippy
+
+  documentation:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      RUSTFLAGS: "-D warnings"
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2.3.4
+
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.rustup
+            ~/.cargo
+            ./target
+          key: docs-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/*.rs') }}
+          restore-keys: docs-${{ hashFiles('**/Cargo.toml') }}-
+
+      - name: Install rust toolchain
+        uses: actions-rs/toolchain@v1.0.7
+        with:
+          toolchain: stable
+          override: true
+          components: clippy, rustfmt
+
+      - name: Build documentation
         run: cargo doc --workspace

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,9 @@ jobs:
             build-${{ matrix.crate }}-${{ matrix.rust }}-${{ hashFiles('**/Cargo.toml') }}-
             build-${{ matrix.crate }}-${{ matrix.rust }}-
 
+      - name: Install dependencies
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libudev-dev libasound2-dev
+
       - name: Install rust toolchain
         uses: actions-rs/toolchain@v1.0.7
         with:
@@ -98,6 +101,9 @@ jobs:
           key: code-style-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/*.rs') }}
           restore-keys: code-style-${{ hashFiles('**/Cargo.toml') }}-
 
+      - name: Install dependencies
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libudev-dev libasound2-dev
+
       - name: Install rust toolchain
         uses: actions-rs/toolchain@v1.0.7
         with:
@@ -130,6 +136,9 @@ jobs:
             ./target
           key: docs-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/*.rs') }}
           restore-keys: docs-${{ hashFiles('**/Cargo.toml') }}-
+
+      - name: Install dependencies
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libudev-dev libasound2-dev
 
       - name: Install rust toolchain
         uses: actions-rs/toolchain@v1.0.7

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -13,3 +13,4 @@ duplicate = "^0.3.0"
 
 [dev-dependencies]
 rstest = "0.7"
+bevy = { version = "^0.5.0", default-features = false, features = ["render"] }

--- a/debug/src/dim2.rs
+++ b/debug/src/dim2.rs
@@ -13,9 +13,9 @@ use super::*;
 
 pub(crate) fn systems() -> SystemSet {
     SystemSet::new()
-        .with_system(dim2::delete_debug_sprite.system())
-        .with_system(dim2::replace_debug_sprite.system())
-        .with_system(dim2::create_debug_sprites.system())
+        .with_system(delete_debug_sprite.system())
+        .with_system(replace_debug_sprite.system())
+        .with_system(create_debug_sprites.system())
 }
 
 fn create_debug_sprites(

--- a/debug/src/dim2.rs
+++ b/debug/src/dim2.rs
@@ -7,7 +7,7 @@ use bevy_prototype_lyon::shapes::RectangleOrigin;
 
 use heron_core::CollisionShape;
 use heron_rapier::convert::IntoBevy;
-use heron_rapier::rapier::geometry::{ColliderHandle, ColliderSet, Shape};
+use heron_rapier::rapier2d::geometry::{ColliderHandle, ColliderSet, Shape};
 
 use super::*;
 

--- a/debug/src/lib.rs
+++ b/debug/src/lib.rs
@@ -7,7 +7,7 @@
 use bevy::prelude::*;
 use fnv::FnvHashMap;
 
-#[cfg(feature = "2d")]
+#[cfg(all(feature = "2d", not(feature = "3d")))]
 mod dim2;
 
 /// Plugin that enables rendering of collision shapes
@@ -44,7 +44,7 @@ impl Default for DebugPlugin {
 
 impl Plugin for DebugPlugin {
     fn build(&self, app: &mut AppBuilder) {
-        #[cfg(feature = "2d")]
+        #[cfg(all(feature = "2d", not(feature = "3d")))]
         app.add_plugin(bevy_prototype_lyon::plugin::ShapePlugin)
             .add_system_set_to_stage(CoreStage::PostUpdate, dim2::systems());
 

--- a/rapier/src/acceleration.rs
+++ b/rapier/src/acceleration.rs
@@ -1,14 +1,13 @@
 use bevy::prelude::*;
-use rapier::{
-    dynamics::RigidBody,
-    math::{Real, Vector},
-};
 
 use heron_core::{utils::NearZero, Acceleration};
 
 use crate::convert::IntoRapier;
 use crate::rapier::dynamics::{RigidBodyHandle, RigidBodySet};
-use crate::rapier::math::AngVector;
+use crate::rapier::{
+    dynamics::RigidBody,
+    math::{AngVector, Vector},
+};
 
 pub(crate) fn update_rapier_force_and_torque(
     mut bodies: ResMut<'_, RigidBodySet>,
@@ -23,7 +22,7 @@ pub(crate) fn update_rapier_force_and_torque(
 
 fn update_acceleration(body: &mut RigidBody, acceleration: &Acceleration) {
     let wake_up = !acceleration.is_near_zero();
-    let linear_acceleration: Vector<Real> = acceleration.linear.into_rapier();
+    let linear_acceleration: Vector<f32> = acceleration.linear.into_rapier();
     let angular_acceleration: AngVector<f32> = acceleration.angular.into_rapier();
     let inertia = {
         #[cfg(dim3)]

--- a/rapier/src/lib.rs
+++ b/rapier/src/lib.rs
@@ -5,12 +5,16 @@
 
 //! Physics behavior for Heron, using [rapier](https://rapier.rs/)
 
-#[cfg(dim2)]
-pub extern crate rapier2d as rapier;
-#[cfg(dim3)]
-pub extern crate rapier3d as rapier;
+#[cfg(feature = "rapier2d")]
+pub extern crate rapier2d;
+#[cfg(feature = "rapier3d")]
+pub extern crate rapier3d;
 
 use bevy::prelude::*;
+#[cfg(dim2)]
+pub(crate) use rapier2d as rapier;
+#[cfg(dim3)]
+pub(crate) use rapier3d as rapier;
 
 use heron_core::{CollisionEvent, PhysicsSystem};
 

--- a/rapier/src/pipeline.rs
+++ b/rapier/src/pipeline.rs
@@ -72,7 +72,7 @@ impl EventHandler for EventManager {
         }
     }
 
-    fn handle_contact_event(&self, event: ContactEvent, _: &rapier::prelude::ContactPair) {
+    fn handle_contact_event(&self, event: ContactEvent, _: &crate::rapier::prelude::ContactPair) {
         if self.contact_send.send(event).is_err() {
             error!("Failed to forward contact event!")
         }

--- a/rapier/src/shape.rs
+++ b/rapier/src/shape.rs
@@ -228,13 +228,13 @@ impl ColliderFactory for CollisionShape {
 }
 
 #[inline]
-#[cfg(feature = "2d")]
+#[cfg(dim2)]
 fn cuboid_builder(half_extends: Vec3) -> ColliderBuilder {
     ColliderBuilder::cuboid(half_extends.x, half_extends.y)
 }
 
 #[inline]
-#[cfg(feature = "3d")]
+#[cfg(dim3)]
 fn cuboid_builder(half_extends: Vec3) -> ColliderBuilder {
     ColliderBuilder::cuboid(half_extends.x, half_extends.y, half_extends.z)
 }
@@ -246,7 +246,7 @@ fn convex_hull_builder(points: &[Vec3]) -> ColliderBuilder {
 }
 
 #[inline]
-#[cfg(feature = "2d")]
+#[cfg(dim2)]
 #[allow(clippy::cast_precision_loss)]
 fn heightfield_builder(size: Vec2, heights: &[Vec<f32>]) -> ColliderBuilder {
     let len = heights.get(0).map(Vec::len).unwrap_or_default();
@@ -257,7 +257,7 @@ fn heightfield_builder(size: Vec2, heights: &[Vec<f32>]) -> ColliderBuilder {
 }
 
 #[inline]
-#[cfg(feature = "3d")]
+#[cfg(dim3)]
 #[allow(clippy::cast_precision_loss)]
 fn heightfield_builder(size: Vec2, heights: &[Vec<f32>]) -> ColliderBuilder {
     let nrows = heights.len();
@@ -334,6 +334,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(any(dim2, dim3))]
     fn build_heightfield() {
         let collider = CollisionShape::HeightField {
             size: Vec2::new(2.0, 1.0),
@@ -347,13 +348,13 @@ mod tests {
             .as_heightfield()
             .expect("Created shape was not a height field");
 
-        #[cfg(feature = "2d")]
+        #[cfg(dim2)]
         {
             assert_eq!(field.num_cells(), 2); // Three points = 2 segments
             assert_eq!(field.cell_width(), 1.0);
         }
 
-        #[cfg(feature = "3d")]
+        #[cfg(dim3)]
         {
             assert_eq!(field.nrows(), 1);
             assert_eq!(field.ncols(), 2);

--- a/rapier/tests/acceleration.rs
+++ b/rapier/tests/acceleration.rs
@@ -1,4 +1,7 @@
 #![cfg(any(dim2, dim3))]
+
+use std::time::Duration;
+
 use bevy::core::CorePlugin;
 use bevy::prelude::*;
 use bevy::prelude::{GlobalTransform, Transform};
@@ -6,10 +9,10 @@ use bevy::reflect::TypeRegistryArc;
 
 use heron_core::{Acceleration, AxisAngle, CollisionShape, PhysicsSteps, RigidBody};
 use heron_rapier::convert::IntoBevy;
-#[cfg(dim3)]
-use heron_rapier::rapier::math::Vector;
-use heron_rapier::{rapier::dynamics::RigidBodySet, RapierPlugin};
-use std::time::Duration;
+use heron_rapier::RapierPlugin;
+use utils::*;
+
+mod utils;
 
 fn test_app() -> App {
     let mut builder = App::build();

--- a/rapier/tests/bodies.rs
+++ b/rapier/tests/bodies.rs
@@ -1,4 +1,5 @@
 #![cfg(any(dim2, dim3))]
+
 use std::f32::consts::PI;
 use std::ops::DerefMut;
 use std::time::Duration;
@@ -9,9 +10,10 @@ use bevy::reflect::TypeRegistryArc;
 
 use heron_core::{CollisionShape, PhysicsSteps, RigidBody};
 use heron_rapier::convert::IntoBevy;
-use heron_rapier::rapier::dynamics::{RigidBodyHandle, RigidBodySet};
-use heron_rapier::rapier::geometry::{ColliderHandle, ColliderSet};
 use heron_rapier::RapierPlugin;
+use utils::*;
+
+mod utils;
 
 fn test_app() -> App {
     let mut builder = App::build();
@@ -77,7 +79,7 @@ fn creates_body_in_rapier_world() {
     #[cfg(dim3)]
     assert_eq!(actual_translation, translation);
 
-    #[cfg(feature = "2d")]
+    #[cfg(dim2)]
     assert_eq!(actual_translation.truncate(), translation.truncate());
 
     let (axis, angle) = rotation.to_axis_angle();
@@ -148,10 +150,10 @@ fn update_rapier_position() {
     let rigid_body = colliders.get(*app.world.get(entity).unwrap()).unwrap();
     let (actual_translation, actual_rotation) = rigid_body.position().into_bevy();
 
-    #[cfg(feature = "3d")]
+    #[cfg(dim3)]
     assert_eq!(actual_translation, translation);
 
-    #[cfg(feature = "2d")]
+    #[cfg(dim2)]
     assert_eq!(actual_translation.truncate(), translation.truncate());
 
     let (axis, angle) = rotation.to_axis_angle();

--- a/rapier/tests/body_types.rs
+++ b/rapier/tests/body_types.rs
@@ -1,4 +1,5 @@
 #![cfg(any(dim2, dim3))]
+
 use std::time::Duration;
 
 use bevy::core::CorePlugin;
@@ -6,9 +7,10 @@ use bevy::prelude::*;
 use bevy::reflect::TypeRegistryArc;
 
 use heron_core::{CollisionShape, PhysicsSteps, RigidBody};
-use heron_rapier::rapier::dynamics::RigidBodySet;
-use heron_rapier::rapier::geometry::ColliderSet;
 use heron_rapier::RapierPlugin;
+use utils::*;
+
+mod utils;
 
 fn test_app() -> App {
     let mut builder = App::build();

--- a/rapier/tests/children_collision_shapes.rs
+++ b/rapier/tests/children_collision_shapes.rs
@@ -7,9 +7,11 @@ use bevy::reflect::TypeRegistryArc;
 
 use heron_core::{CollisionShape, PhysicsSteps, RigidBody};
 use heron_rapier::convert::IntoBevy;
-use heron_rapier::rapier::dynamics::RigidBodySet;
-use heron_rapier::rapier::geometry::ColliderSet;
 use heron_rapier::RapierPlugin;
+
+use utils::*;
+
+mod utils;
 
 fn test_app() -> App {
     let mut builder = App::build();

--- a/rapier/tests/constraints.rs
+++ b/rapier/tests/constraints.rs
@@ -1,4 +1,4 @@
-#![cfg(all(feature = "2d", not(feature = "3d")))]
+#![cfg(dim2)]
 
 use std::time::Duration;
 
@@ -7,8 +7,10 @@ use bevy::prelude::*;
 use bevy::reflect::TypeRegistryArc;
 
 use heron_core::{CollisionShape, PhysicsSteps, RigidBody, RotationConstraints};
-use heron_rapier::rapier::dynamics::RigidBodySet;
 use heron_rapier::RapierPlugin;
+use utils::*;
+
+mod utils;
 
 fn test_app() -> App {
     let mut builder = App::build();

--- a/rapier/tests/density.rs
+++ b/rapier/tests/density.rs
@@ -1,4 +1,5 @@
 #![cfg(any(dim2, dim3))]
+
 use std::time::Duration;
 
 use bevy::core::CorePlugin;
@@ -8,8 +9,10 @@ use bevy::reflect::TypeRegistryArc;
 use heron_core::utils::NearZero;
 use heron_core::{CollisionShape, PhysicMaterial, PhysicsSteps, RigidBody};
 use heron_rapier::convert::IntoBevy;
-use heron_rapier::rapier::dynamics::{MassProperties, RigidBodySet};
 use heron_rapier::RapierPlugin;
+use utils::*;
+
+mod utils;
 
 fn test_app() -> App {
     let mut builder = App::build();

--- a/rapier/tests/events.rs
+++ b/rapier/tests/events.rs
@@ -5,9 +5,12 @@ use bevy::prelude::*;
 use bevy::reflect::TypeRegistryArc;
 
 use heron_core::{CollisionEvent, CollisionShape, PhysicsSteps, RigidBody, Velocity};
-use heron_rapier::rapier::dynamics::IntegrationParameters;
 use heron_rapier::RapierPlugin;
 use std::time::Duration;
+
+use utils::*;
+
+mod utils;
 
 fn test_app() -> App {
     let mut builder = App::build();

--- a/rapier/tests/friction.rs
+++ b/rapier/tests/friction.rs
@@ -1,4 +1,5 @@
 #![cfg(any(dim2, dim3))]
+
 use std::time::Duration;
 
 use bevy::core::CorePlugin;
@@ -6,8 +7,10 @@ use bevy::prelude::*;
 use bevy::reflect::TypeRegistryArc;
 
 use heron_core::{CollisionShape, PhysicMaterial, PhysicsSteps, RigidBody};
-use heron_rapier::rapier::geometry::ColliderSet;
 use heron_rapier::RapierPlugin;
+use utils::*;
+
+mod utils;
 
 fn test_app() -> App {
     let mut builder = App::build();

--- a/rapier/tests/layers.rs
+++ b/rapier/tests/layers.rs
@@ -1,12 +1,16 @@
 #![cfg(any(dim2, dim3))]
+
+use std::time::Duration;
+
 use bevy::core::CorePlugin;
 use bevy::prelude::*;
 use bevy::reflect::TypeRegistryArc;
 
 use heron_core::{CollisionLayers, CollisionShape, PhysicsLayer, PhysicsSteps, RigidBody};
-use heron_rapier::rapier::geometry::ColliderSet;
 use heron_rapier::RapierPlugin;
-use std::time::Duration;
+use utils::*;
+
+mod utils;
 
 enum TestLayer {
     A,

--- a/rapier/tests/resources.rs
+++ b/rapier/tests/resources.rs
@@ -1,4 +1,5 @@
 #![cfg(any(dim2, dim3))]
+
 use bevy::app::prelude::*;
 use bevy::core::CorePlugin;
 use bevy::math::prelude::*;
@@ -6,9 +7,10 @@ use bevy::reflect::TypeRegistryArc;
 
 use heron_core::Gravity;
 use heron_core::PhysicsTime;
-use heron_rapier::rapier::dynamics::{IntegrationParameters, JointSet, RigidBodySet};
-use heron_rapier::rapier::geometry::ColliderSet;
 use heron_rapier::RapierPlugin;
+use utils::*;
+
+mod utils;
 
 #[test]
 fn can_define_gravity_before_plugin() {

--- a/rapier/tests/restitution.rs
+++ b/rapier/tests/restitution.rs
@@ -1,12 +1,16 @@
 #![cfg(any(dim2, dim3))]
+
+use std::time::Duration;
+
 use bevy::core::CorePlugin;
 use bevy::prelude::*;
 use bevy::reflect::TypeRegistryArc;
 
 use heron_core::{CollisionShape, PhysicMaterial, PhysicsSteps, RigidBody};
-use heron_rapier::rapier::geometry::ColliderSet;
 use heron_rapier::RapierPlugin;
-use std::time::Duration;
+use utils::*;
+
+mod utils;
 
 fn test_app() -> App {
     let mut builder = App::build();

--- a/rapier/tests/sensor_shape.rs
+++ b/rapier/tests/sensor_shape.rs
@@ -1,4 +1,5 @@
 #![cfg(any(dim2, dim3))]
+
 use std::time::Duration;
 
 use bevy::core::CorePlugin;
@@ -6,9 +7,10 @@ use bevy::prelude::*;
 use bevy::reflect::TypeRegistryArc;
 
 use heron_core::{CollisionShape, PhysicsSteps, RigidBody, SensorShape};
-use heron_rapier::rapier::dynamics::IntegrationParameters;
-use heron_rapier::rapier::geometry::ColliderSet;
 use heron_rapier::RapierPlugin;
+use utils::*;
+
+mod utils;
 
 fn test_app() -> App {
     let mut builder = App::build();

--- a/rapier/tests/utils/mod.rs
+++ b/rapier/tests/utils/mod.rs
@@ -1,0 +1,13 @@
+#[allow(unused_imports)]
+#[cfg(dim2)]
+pub use heron_rapier::rapier2d::{
+    dynamics::{IntegrationParameters, JointSet, MassProperties, RigidBodyHandle, RigidBodySet},
+    geometry::{ColliderHandle, ColliderSet},
+    math::Vector,
+};
+#[cfg(dim3)]
+pub use heron_rapier::rapier3d::{
+    dynamics::{IntegrationParameters, JointSet, MassProperties, RigidBodyHandle, RigidBodySet},
+    geometry::{ColliderHandle, ColliderSet},
+    math::Vector,
+};

--- a/rapier/tests/velocity.rs
+++ b/rapier/tests/velocity.rs
@@ -10,8 +10,10 @@ use rstest::rstest;
 
 use heron_core::*;
 use heron_rapier::convert::IntoBevy;
-use heron_rapier::rapier::dynamics::RigidBodySet;
 use heron_rapier::RapierPlugin;
+use utils::*;
+
+mod utils;
 
 fn test_app() -> App {
     let mut builder = App::build();

--- a/release.yml
+++ b/release.yml
@@ -1,9 +1,11 @@
 hooks:
   verify:
     - cargo test --workspace
+    - cargo test --workspace --no-default-features
     - cargo test --workspace --no-default-features --features "2d"
-    - cargo test --workspace --no-default-features --features "2d, debug-2d"
     - cargo test --workspace --no-default-features --features "3d"
+    - cargo test --workspace --no-default-features --features "debug-2d"
+    - cargo test --workspace --all-features
 
   prepare:
     - "sed -i 's/\".*\" # auto-version/\"{{version}}\" # auto-version/' core/Cargo.toml"


### PR DESCRIPTION
Fix #124 

`heron_rapier` no longer exports the rapier as `rapier` but as either `rapier2d` or `rapier3d` (or both) depending on the feature flags.
