### PR TITLE
Add cone shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ The format is inspired from [Keep a Changelog], and this project adheres to [Sem
 
 ## [Unreleased]
 
+### Breaking changes
+
+The `CollisionShape` is now marked `#[non_exhaustive]`
+
+### Added
+
+Cone collision shape
 
 
 ## [0.12.1] - 2021-10-24

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ all-features = true
 [features]
 default = []
 2d = ["heron_rapier/2d"]
-3d = ["heron_rapier/3d"]
+3d = ["heron_rapier/3d", "heron_core/3d"]
 debug-2d = ["2d", "heron_debug/2d"]
 debug-3d = ["3d", "heron_debug/3d"]
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -8,6 +8,13 @@ license = "MIT"
 description = "Core components and resources to use Heron"
 repository = "https://github.com/jcornaz/heron/"
 
+[package.metadata.docs.rs]
+all-features = true
+
+[features]
+default = []
+3d = []
+
 [dependencies]
 bevy = { version = "0.5.0", default-features = false }
 duplicate = "0.3.0"
@@ -15,3 +22,6 @@ duplicate = "0.3.0"
 [dev-dependencies]
 rstest = "0.7"
 bevy = { version = "0.5.0", default-features = false, features = ["render"] }
+
+[build-dependencies]
+cfg_aliases = "0.1.1"

--- a/core/build.rs
+++ b/core/build.rs
@@ -3,7 +3,6 @@ fn main() {
         // 2D feature is only enabled if 3D is not enabled
         dim2: { all(feature = "2d", not(feature = "3d")) },
         // 3D feature takes precedence over 2D feature
-        dim3: { all(feature = "3d") },
-        debug: { any(feature = "debug-2d", feature = "debug-3d") }
+        dim3: { all(feature = "3d") }
     }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -109,6 +109,7 @@ pub fn should_run(
 /// }
 /// ```
 #[derive(Debug, Clone, Reflect)]
+#[non_exhaustive]
 pub enum CollisionShape {
     /// A sphere (or circle in 2d) shape defined by its radius
     Sphere {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -107,6 +107,7 @@ pub fn should_run(
 ///         .insert(RigidBody::Dynamic) // Create a dynamic rigid body
 ///         .insert(CollisionShape::Sphere { radius: 1.0 }); // Attach a collision shape
 /// }
+/// ```
 #[derive(Debug, Clone, Reflect)]
 pub enum CollisionShape {
     /// A sphere (or circle in 2d) shape defined by its radius
@@ -162,6 +163,18 @@ pub enum CollisionShape {
         /// In 2D, the outer `Vec` should contain only one
         /// inner `Vec`, any other element will be ignored.
         heights: Vec<Vec<f32>>,
+    },
+
+    /// A Cone shape, like a traffic cone, with a circular base
+    ///
+    /// This shape is exclusive to the 3d API, you must enable the "3d" flag to use it.
+    /// For the 2d equivalent, look at [`Sphere`](CollisionShape::Sphere).
+    #[cfg(dim3)]
+    Cone {
+        /// Half of the height from the base of the cone to the top point
+        half_height: f32,
+        /// The radius of the base circle
+        radius: f32,
     },
 }
 

--- a/debug/src/dim2.rs
+++ b/debug/src/dim2.rs
@@ -257,6 +257,12 @@ fn base_builder(body: &CollisionShape, shape: &dyn Shape) -> GeometryBuilder {
                 });
             }
         }
+        any_other => {
+            warn!(
+                "Debug render for this shape {:?} is unimplemented",
+                any_other
+            );
+        }
     };
 
     builder

--- a/debug/src/dim3.rs
+++ b/debug/src/dim3.rs
@@ -63,6 +63,12 @@ fn add_shape_outlines(
             } => {
                 add_cone(origin, orient, *half_height, *radius, color, &mut lines);
             }
+            any_other => {
+                warn!(
+                    "Debug render for this shape {:?} is unimplemented",
+                    any_other
+                );
+            }
         }
     }
 }

--- a/debug/src/dim3.rs
+++ b/debug/src/dim3.rs
@@ -4,7 +4,8 @@ use bevy_prototype_debug_lines::DebugLines;
 use heron_core::{CollisionShape, RigidBody, SensorShape};
 
 use crate::shape3d_wireframe::{
-    add_capsule, add_convex_hull, add_cuboid, add_height_field, add_rounded_cuboid, add_sphere,
+    add_capsule, add_cone, add_convex_hull, add_cuboid, add_height_field, add_rounded_cuboid,
+    add_sphere,
 };
 
 use super::DebugColor;
@@ -55,6 +56,12 @@ fn add_shape_outlines(
             }
             CollisionShape::HeightField { size, heights } => {
                 add_height_field(origin, orient, *size, heights, color, &mut lines);
+            }
+            CollisionShape::Cone {
+                half_height,
+                radius,
+            } => {
+                add_cone(origin, orient, *half_height, *radius, color, &mut lines);
             }
         }
     }

--- a/debug/src/shape3d_wireframe.rs
+++ b/debug/src/shape3d_wireframe.rs
@@ -168,6 +168,24 @@ fn add_circle(origin: Vec3, orient: Quat, radius: f32, color: Color, lines: &mut
     add_semicircle(origin, orient, radius, color, lines);
     add_semicircle(origin, orient * x_rotate, radius, color, lines);
 }
+pub(crate) fn add_cone(
+    origin: Vec3,
+    orient: Quat,
+    half_height: f32,
+    radius: f32,
+    color: Color,
+    lines: &mut DebugLines,
+) {
+    let cone_base = orient * (Vec3::Y * -half_height) + origin;
+    let cone_top = orient * (Vec3::Y * half_height) + origin;
+    let x_rotate = Quat::from_rotation_x(FRAC_PI_2);
+    let on_base_edge = |axis: Vec3, dir: f32| cone_base + dir * (orient * radius * axis);
+    add_circle(cone_base, orient * x_rotate, radius, color, lines);
+    lines.line_colored(on_base_edge(Vec3::Z, 1.0), cone_top, 0.0, color);
+    lines.line_colored(on_base_edge(Vec3::Z, -1.0), cone_top, 0.0, color);
+    lines.line_colored(on_base_edge(Vec3::X, 1.0), cone_top, 0.0, color);
+    lines.line_colored(on_base_edge(Vec3::X, -1.0), cone_top, 0.0, color);
+}
 pub(crate) fn add_sphere(
     origin: Vec3,
     orient: Quat,

--- a/examples/debug_3d.rs
+++ b/examples/debug_3d.rs
@@ -124,6 +124,28 @@ fn setup(
         .insert(RigidBody::Dynamic)
         .insert(CollisionShape::Sphere { radius: 1.0 });
 
+    // Cone
+    commands
+        .spawn_bundle(PbrBundle {
+            mesh: meshes.add(Mesh::from(shape::Capsule {
+                radius: 0.5,
+                depth: 2.0,
+                ..Default::default()
+            })),
+            material: materials.add(Color::RED.into()),
+            ..Default::default()
+        })
+        .insert(Transform {
+            translation: Vec3::new(5., 15., -7.),
+            ..Default::default()
+        })
+        .insert(GlobalTransform::identity())
+        .insert(RigidBody::Dynamic)
+        .insert(CollisionShape::Cone {
+            half_height: 2.0,
+            radius: 1.0,
+        });
+
     // Capsule
     commands
         .spawn_bundle(PbrBundle {

--- a/rapier/Cargo.toml
+++ b/rapier/Cargo.toml
@@ -14,7 +14,7 @@ all-features = true
 [features]
 default = []
 2d = ["rapier2d"]
-3d = ["rapier3d"]
+3d = ["rapier3d", "heron_core/3d"]
 
 [dependencies]
 heron_core = { version = "0.12.1", path = "../core" }

--- a/rapier/src/shape.rs
+++ b/rapier/src/shape.rs
@@ -229,6 +229,10 @@ impl ColliderFactory for CollisionShape {
                 border_radius,
             } => convex_hull_builder(points.as_slice(), *border_radius),
             CollisionShape::HeightField { size, heights } => heightfield_builder(*size, heights),
+            CollisionShape::Cone {
+                half_height,
+                radius,
+            } => ColliderBuilder::cone(*half_height, *radius),
         }
         // General all types of collision events
         .active_events(ActiveEvents::all())

--- a/rapier/src/shape.rs
+++ b/rapier/src/shape.rs
@@ -229,10 +229,18 @@ impl ColliderFactory for CollisionShape {
                 border_radius,
             } => convex_hull_builder(points.as_slice(), *border_radius),
             CollisionShape::HeightField { size, heights } => heightfield_builder(*size, heights),
+            #[cfg(dim3)]
             CollisionShape::Cone {
                 half_height,
                 radius,
             } => ColliderBuilder::cone(*half_height, *radius),
+            any_other => {
+                warn!(
+                    "Tried to build an nonexistent CollisionShape {:?}, falling back to a Sphere",
+                    any_other
+                );
+                ColliderBuilder::ball(1.0)
+            }
         }
         // General all types of collision events
         .active_events(ActiveEvents::all())


### PR DESCRIPTION
Note: I didn't add `#[non_exhaustive]` to `CollisionShape` **because of the `match` in `rapier/src/shape.rs` line 236**. It would otherwise require adding a `_ => panic!("shape not supported"),` branch to the match expression. I thought it would be more questionable than not adding `#[non_exhaustive]`.