### PR TITLE
Support custom collision shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is inspired from [Keep a Changelog], and this project adheres to [Sem
 
 * Cone collision shape (#158)
 * Cylinder collision shape (#159)
+* Custom collision shape
 
 
 ## [0.12.1] - 2021-10-24

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -91,6 +91,33 @@ pub fn should_run(
     }
 }
 
+/// TODO
+#[derive(Clone)]
+pub struct CustomCollisionShape(
+    std::sync::Arc<dyn std::any::Any + Send + Sync>,
+    &'static str,
+);
+
+impl CustomCollisionShape {
+    /// TODO
+    pub fn new<T: std::any::Any + Send + Sync>(shape: T) -> Self {
+        Self(std::sync::Arc::new(shape), std::any::type_name::<T>())
+    }
+
+    /// TODO
+    pub fn downcast_ref<T: std::any::Any>(&self) -> Option<&T> {
+        self.0.downcast_ref()
+    }
+}
+
+impl core::fmt::Debug for CustomCollisionShape {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_tuple("CustomCollisionShape")
+            .field(&format_args!("{}", &self.1))
+            .finish()
+    }
+}
+
 /// Components that defines the collision shape of a rigid body
 ///
 /// The collision shape will be attached to the [`RigidBody`] of the same entity.
@@ -188,6 +215,12 @@ pub enum CollisionShape {
         half_height: f32,
         /// The radius of the base circle
         radius: f32,
+    },
+
+    /// TODO
+    Custom {
+        /// TODO
+        shape: CustomCollisionShape,
     },
 }
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -4,6 +4,9 @@
 
 //! Core components and resources to use Heron
 
+use core::any::Any;
+use std::sync::Arc;
+
 use bevy::ecs::schedule::ShouldRun;
 use bevy::prelude::*;
 
@@ -93,19 +96,16 @@ pub fn should_run(
 
 /// TODO
 #[derive(Clone)]
-pub struct CustomCollisionShape(
-    std::sync::Arc<dyn std::any::Any + Send + Sync>,
-    &'static str,
-);
+pub struct CustomCollisionShape(Arc<dyn Any + Send + Sync>, &'static str);
 
 impl CustomCollisionShape {
     /// TODO
-    pub fn new<T: std::any::Any + Send + Sync>(shape: T) -> Self {
-        Self(std::sync::Arc::new(shape), std::any::type_name::<T>())
+    pub fn new<T: Any + Send + Sync>(shape: T) -> Self {
+        Self(Arc::new(shape), std::any::type_name::<T>())
     }
 
     /// TODO
-    pub fn downcast_ref<T: std::any::Any>(&self) -> Option<&T> {
+    pub fn downcast_ref<T: Any>(&self) -> Option<&T> {
         self.0.downcast_ref()
     }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -94,17 +94,23 @@ pub fn should_run(
     }
 }
 
-/// TODO
+/// An opaque type representing a custom collision shape.
+///
+/// It will accept [`Any`] type, but the implementation is abstract, and
+/// what actual values will work depends on the backend, so see
+/// the relevant backend documentation to learn what types are accepted here.
 #[derive(Clone)]
 pub struct CustomCollisionShape(Arc<dyn Any + Send + Sync>, &'static str);
 
 impl CustomCollisionShape {
-    /// TODO
+    /// Create a new [`CustomCollisionShape`] that wraps some value.
     pub fn new<T: Any + Send + Sync>(shape: T) -> Self {
         Self(Arc::new(shape), std::any::type_name::<T>())
     }
 
-    /// TODO
+    /// Check if the stored value is of type `T`, and give a reference to it
+    /// if the type matches.
+    /// Will return [`None`] if the type of the stored value does not match `T`.
     pub fn downcast_ref<T: Any>(&self) -> Option<&T> {
         self.0.downcast_ref()
     }
@@ -217,9 +223,12 @@ pub enum CollisionShape {
         radius: f32,
     },
 
-    /// TODO
+    /// A Custom shape, the actual shape is abstracted, and will be determined
+    /// by a corresponding backend depending on the implementation details
+    ///
+    /// See [`CustomCollisionShape`] for more info.
     Custom {
-        /// TODO
+        /// The custom collision shape to use
         shape: CustomCollisionShape,
     },
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -111,6 +111,7 @@ impl CustomCollisionShape {
     /// Check if the stored value is of type `T`, and give a reference to it
     /// if the type matches.
     /// Will return [`None`] if the type of the stored value does not match `T`.
+    #[must_use]
     pub fn downcast_ref<T: Any>(&self) -> Option<&T> {
         self.0.downcast_ref()
     }

--- a/rapier/src/lib.rs
+++ b/rapier/src/lib.rs
@@ -4,6 +4,13 @@
 #![cfg(any(dim2, dim3))]
 
 //! Physics behavior for Heron, using [rapier](https://rapier.rs/)
+//!
+//! # Supported custom collision shapes
+//!
+//! The following types are accepted as [`heron_core::CustomCollisionShape`]
+//! values.
+//!
+//! - [`rapier::geometry::ColliderBuilder`]
 
 #[cfg(feature = "rapier2d")]
 pub extern crate rapier2d;

--- a/rapier/src/shape.rs
+++ b/rapier/src/shape.rs
@@ -243,7 +243,7 @@ impl ColliderFactory for CollisionShape {
                 if let Some(builder) = shape.downcast_ref::<ColliderBuilder>() {
                     builder.clone()
                 } else {
-                    panic!("Unsupported custom builder is used: {:?}", shape);
+                    panic!("Unsupported custom collision shape is used: {:?}", shape);
                 }
             }
             any_other => {
@@ -438,7 +438,9 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Unsupported custom builder is used: CustomCollisionShape(())")]
+    #[should_panic(
+        expected = "Unsupported custom collision shape is used: CustomCollisionShape(())"
+    )]
     fn build_custom_unsupported() {
         let _ = CollisionShape::Custom {
             shape: CustomCollisionShape::new(()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,6 +118,7 @@
 //! * How to define the [`PhysicMaterial`]
 //! * How to listen to [`CollisionEvent`]
 //! * How to define [`RotationConstraints`]
+//! * How to define [`CustomCollisionShape`] for [`heron_rapier`]
 
 use bevy::app::{AppBuilder, Plugin};
 


### PR DESCRIPTION
This PR implements a (draft so far) support for custom collision shapes. The definition of the custom collision shape at the core is abstract from a backend implementation (i.e. `rapier`), but the backend can define the type it supports.

The goal is to enable projects to tighter integrate with backends (in the current case - just `rapier`) where needed - for instance, to use a currently unsupported collision shape - while not coupling the core with any particular backend.

Please take a look, and if you like the idea I can quickly beautify this into a production-ready form.