### PR TITLE
chore: small clippy improvements

### DIFF
--- a/core/src/constraints.rs
+++ b/core/src/constraints.rs
@@ -40,7 +40,8 @@ impl Default for RotationConstraints {
 impl RotationConstraints {
     /// Lock rotations around all axes
     #[must_use]
-    pub fn lock() -> Self {
+    #[inline]
+    pub const fn lock() -> Self {
         Self {
             allow_x: false,
             allow_y: false,
@@ -50,7 +51,8 @@ impl RotationConstraints {
 
     /// Allow rotations around all axes
     #[must_use]
-    pub fn allow() -> Self {
+    #[inline]
+    pub const fn allow() -> Self {
         Self {
             allow_x: true,
             allow_y: true,
@@ -60,7 +62,8 @@ impl RotationConstraints {
 
     /// Allow rotation around the x axis only (and prevent rotating around the other axes)
     #[must_use]
-    pub fn restrict_to_x_only() -> Self {
+    #[inline]
+    pub const fn restrict_to_x_only() -> Self {
         Self {
             allow_x: true,
             allow_y: false,
@@ -70,7 +73,8 @@ impl RotationConstraints {
 
     /// Allow rotation around the y axis only (and prevent rotating around the other axes)
     #[must_use]
-    pub fn restrict_to_y_only() -> Self {
+    #[inline]
+    pub const fn restrict_to_y_only() -> Self {
         Self {
             allow_x: false,
             allow_y: true,
@@ -80,7 +84,8 @@ impl RotationConstraints {
 
     /// Allow rotation around the z axis only (and prevent rotating around the other axes)
     #[must_use]
-    pub fn restrict_to_z_only() -> Self {
+    #[inline]
+    pub const fn restrict_to_z_only() -> Self {
         Self {
             allow_x: false,
             allow_y: false,

--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -48,12 +48,14 @@ impl From<CollisionEvent> for (CollisionData, CollisionData) {
 impl CollisionEvent {
     /// Returns true if the event represent the "start" of a collision
     #[must_use]
+    #[inline]
     pub fn is_started(&self) -> bool {
         matches!(self, CollisionEvent::Started(_, _))
     }
 
     /// Returns true if the event represent the "end" of a collision
     #[must_use]
+    #[inline]
     pub fn is_stopped(&self) -> bool {
         matches!(self, CollisionEvent::Stopped(_, _))
     }

--- a/core/src/layers.rs
+++ b/core/src/layers.rs
@@ -184,12 +184,14 @@ impl CollisionLayers {
 
     #[must_use]
     #[allow(missing_docs)]
+    #[inline]
     pub fn groups_bits(self) -> u32 {
         self.groups
     }
 
     #[must_use]
     #[allow(missing_docs)]
+    #[inline]
     pub fn masks_bits(self) -> u32 {
         self.masks
     }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,5 +1,14 @@
 #![deny(future_incompatible, nonstandard_style)]
-#![warn(missing_docs, rust_2018_idioms, clippy::pedantic)]
+#![warn(
+    missing_docs,
+    rust_2018_idioms,
+    clippy::pedantic,
+    clippy::all,
+    clippy::style,
+    clippy::complexity,
+    clippy::perf,
+    clippy::suspicious
+)]
 #![allow(clippy::module_name_repetitions, clippy::needless_pass_by_value)]
 
 //! Core components and resources to use Heron
@@ -307,7 +316,8 @@ impl Default for RigidBody {
 impl RigidBody {
     /// Returns true if this body type can be moved by [`Velocity`]
     #[must_use]
-    pub fn can_have_velocity(self) -> bool {
+    #[inline]
+    pub const fn can_have_velocity(self) -> bool {
         match self {
             RigidBody::Dynamic | RigidBody::KinematicVelocityBased => true,
             RigidBody::Static | RigidBody::Sensor | RigidBody::KinematicPositionBased => false,

--- a/core/src/physics_time.rs
+++ b/core/src/physics_time.rs
@@ -29,6 +29,7 @@ impl PhysicsTime {
     /// Panic if the scale is negative.
     ///
     #[must_use]
+    #[inline]
     pub fn new(scale: f32) -> Self {
         assert!(scale >= 0.0, "Negative scale: {}", scale);
         Self {
@@ -38,12 +39,14 @@ impl PhysicsTime {
     }
 
     /// Pause the physics emulation, avoiding heron systems to run.
+    #[inline]
     pub fn pause(&mut self) {
         self.previous_scale = Some(self.scale);
         self.scale = 0.0;
     }
 
     /// Resume the physics emulation
+    #[inline]
     pub fn resume(&mut self) {
         if let Some(prev) = self.previous_scale {
             self.scale = prev;
@@ -57,6 +60,7 @@ impl PhysicsTime {
     ///
     /// Panic if the scale is negative
     ///
+    #[inline]
     pub fn set_scale(&mut self, scale: f32) {
         assert!(scale >= 0.0);
         self.scale = scale;
@@ -64,7 +68,8 @@ impl PhysicsTime {
 
     /// Get the physics emulation time scale
     #[must_use]
-    pub fn scale(&self) -> f32 {
+    #[inline]
+    pub const fn scale(&self) -> f32 {
         self.scale
     }
 

--- a/core/src/step.rs
+++ b/core/src/step.rs
@@ -152,7 +152,7 @@ impl PhysicsSteps {
         }
     }
 
-    pub(crate) fn update(mut physics_steps: ResMut<'_, PhysicsSteps>, time: Res<'_, Time>) {
+    pub(crate) fn update(mut physics_steps: ResMut<'_, Self>, time: Res<'_, Time>) {
         physics_steps.do_update(time.delta());
     }
 

--- a/core/src/velocity.rs
+++ b/core/src/velocity.rs
@@ -111,6 +111,7 @@ pub struct AxisAngle(Vec3);
 impl Velocity {
     /// Returns a linear velocity from a vector
     #[must_use]
+    #[inline]
     pub fn from_linear(linear: Vec3) -> Self {
         Self {
             linear,
@@ -120,6 +121,7 @@ impl Velocity {
 
     /// Returns an angular velocity from a vector
     #[must_use]
+    #[inline]
     pub fn from_angular(angular: AxisAngle) -> Self {
         Self {
             angular,
@@ -129,6 +131,7 @@ impl Velocity {
 
     /// Returns a new version with the given linear velocity
     #[must_use]
+    #[inline]
     pub fn with_linear(mut self, linear: Vec3) -> Self {
         self.linear = linear;
         self
@@ -136,6 +139,7 @@ impl Velocity {
 
     /// Returns a new version with the given angular velocity
     #[must_use]
+    #[inline]
     pub fn with_angular(mut self, angular: AxisAngle) -> Self {
         self.angular = angular;
         self
@@ -145,6 +149,7 @@ impl Velocity {
 impl Acceleration {
     /// Returns a linear acceleration from a vector
     #[must_use]
+    #[inline]
     pub fn from_linear(linear: Vec3) -> Self {
         Self {
             linear,
@@ -154,6 +159,7 @@ impl Acceleration {
 
     /// Returns an angular acceleration from a vector
     #[must_use]
+    #[inline]
     pub fn from_angular(angular: AxisAngle) -> Self {
         Self {
             angular,
@@ -163,6 +169,7 @@ impl Acceleration {
 
     /// Returns a new version with the given linear acceleration
     #[must_use]
+    #[inline]
     pub fn with_linear(mut self, linear: Vec3) -> Self {
         self.linear = linear;
         self
@@ -170,6 +177,7 @@ impl Acceleration {
 
     /// Returns a new version with the given angular acceleration
     #[must_use]
+    #[inline]
     pub fn with_angular(mut self, angular: AxisAngle) -> Self {
         self.angular = angular;
         self
@@ -179,7 +187,8 @@ impl Acceleration {
 impl Damping {
     /// Returns a linear damping
     #[must_use]
-    pub fn from_linear(linear: f32) -> Self {
+    #[inline]
+    pub const fn from_linear(linear: f32) -> Self {
         Self {
             linear,
             angular: 0.0,
@@ -188,7 +197,8 @@ impl Damping {
 
     /// Returns an angular damping
     #[must_use]
-    pub fn from_angular(angular: f32) -> Self {
+    #[inline]
+    pub const fn from_angular(angular: f32) -> Self {
         Self {
             angular,
             linear: 0.0,
@@ -197,14 +207,16 @@ impl Damping {
 
     /// Returns a new version with the given linear damping
     #[must_use]
-    pub fn with_linear(mut self, linear: f32) -> Self {
+    #[inline]
+    pub const fn with_linear(mut self, linear: f32) -> Self {
         self.linear = linear;
         self
     }
 
     /// Returns a new version with the given angular damping
     #[must_use]
-    pub fn with_angular(mut self, angular: f32) -> Self {
+    #[inline]
+    pub const fn with_angular(mut self, angular: f32) -> Self {
         self.angular = angular;
         self
     }
@@ -391,10 +403,10 @@ impl From<Quat> for AxisAngle {
 impl From<AxisAngle> for Quat {
     fn from(axis_angle: AxisAngle) -> Self {
         if axis_angle.is_near_zero() {
-            Quat::IDENTITY
+            Self::IDENTITY
         } else {
             let angle = axis_angle.0.length();
-            Quat::from_axis_angle(axis_angle.0 / angle, angle)
+            Self::from_axis_angle(axis_angle.0 / angle, angle)
         }
     }
 }

--- a/debug/src/dim2.rs
+++ b/debug/src/dim2.rs
@@ -163,8 +163,8 @@ fn base_builder(body: &CollisionShape, shape: &dyn Shape) -> GeometryBuilder {
             }
             impl Geometry for RoundedRectangle {
                 fn add_geometry(&self, b: &mut Builder) {
-                    let real_width = self.width + self.radius * 2.0;
-                    let real_height = self.height + self.radius * 2.0;
+                    let real_width = self.radius.mul_add(2.0, self.width);
+                    let real_height = self.radius.mul_add(2.0, self.height);
                     b.add_rounded_rectangle(
                         &Rect::new(
                             Point::new(-real_width / 2.0, -real_height / 2.0),

--- a/debug/src/lib.rs
+++ b/debug/src/lib.rs
@@ -1,5 +1,14 @@
 #![deny(future_incompatible, nonstandard_style)]
-#![warn(missing_docs, rust_2018_idioms, clippy::pedantic)]
+#![warn(
+    missing_docs,
+    rust_2018_idioms,
+    clippy::pedantic,
+    clippy::all,
+    clippy::style,
+    clippy::complexity,
+    clippy::perf,
+    clippy::suspicious
+)]
 #![allow(
     clippy::needless_pass_by_value,
     clippy::type_complexity,

--- a/rapier/src/body.rs
+++ b/rapier/src/body.rs
@@ -243,7 +243,8 @@ pub(crate) fn update_bevy_transform(
     }
 }
 
-fn body_status(body_type: RigidBody) -> RigidBodyType {
+#[inline]
+const fn body_status(body_type: RigidBody) -> RigidBodyType {
     match body_type {
         RigidBody::Dynamic => RigidBodyType::Dynamic,
         RigidBody::Static | RigidBody::Sensor => RigidBodyType::Static,

--- a/rapier/src/convert.rs
+++ b/rapier/src/convert.rs
@@ -135,7 +135,7 @@ impl IntoBevy<Vec<Vec2>> for &[Point2<f32>] {
 
 impl IntoRapier<Translation<f32>> for Vec3 {
     fn into_rapier(self) -> Translation<f32> {
-        <Vec3 as IntoRapier<Vector<f32>>>::into_rapier(self).into()
+        <Self as IntoRapier<Vector<f32>>>::into_rapier(self).into()
     }
 }
 

--- a/rapier/src/lib.rs
+++ b/rapier/src/lib.rs
@@ -1,5 +1,14 @@
 #![deny(future_incompatible, nonstandard_style)]
-#![warn(missing_docs, rust_2018_idioms, clippy::pedantic)]
+#![warn(
+    missing_docs,
+    rust_2018_idioms,
+    clippy::pedantic,
+    clippy::all,
+    clippy::style,
+    clippy::complexity,
+    clippy::perf,
+    clippy::suspicious
+)]
 #![allow(
     clippy::needless_pass_by_value,
     clippy::type_complexity,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,14 @@
 #![deny(future_incompatible, nonstandard_style)]
-#![warn(missing_docs, rust_2018_idioms, clippy::pedantic)]
+#![warn(
+    missing_docs,
+    rust_2018_idioms,
+    clippy::pedantic,
+    clippy::all,
+    clippy::style,
+    clippy::complexity,
+    clippy::perf,
+    clippy::suspicious
+)]
 #![allow(clippy::needless_pass_by_value, clippy::needless_doctest_main)]
 #![cfg(any(dim2, dim3))]
 


### PR DESCRIPTION
- I noticed a few types with `const` evaluation could have `const` methods
- I added some `inline` hints on small and straightforward methods
- `clippy::nursery` gave a few warnings that I fixed