### PR TITLE
refactor: remove all .system()

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -76,7 +76,7 @@ impl Plugin for CorePlugin {
             .register_type::<RotationConstraints>()
             .register_type::<CollisionLayers>()
             .register_type::<SensorShape>()
-            .add_system_to_stage(CoreStage::First, PhysicsSteps::update.system())
+            .add_system_to_stage(CoreStage::First, PhysicsSteps::update)
             .add_stage_before(CoreStage::PostUpdate, crate::stage::ROOT, {
                 Schedule::default().with_stage(crate::stage::UPDATE, SystemStage::parallel())
             });

--- a/debug/src/dim2.rs
+++ b/debug/src/dim2.rs
@@ -19,9 +19,9 @@ use super::*;
 
 pub(crate) fn systems() -> SystemSet {
     SystemSet::new()
-        .with_system(delete_debug_sprite.system())
-        .with_system(replace_debug_sprite.system())
-        .with_system(create_debug_sprites.system())
+        .with_system(delete_debug_sprite)
+        .with_system(replace_debug_sprite)
+        .with_system(create_debug_sprites)
 }
 
 fn create_debug_sprites(

--- a/debug/src/dim3.rs
+++ b/debug/src/dim3.rs
@@ -81,5 +81,5 @@ fn add_shape_outlines(
 }
 
 pub(crate) fn systems() -> SystemSet {
-    SystemSet::new().with_system(add_shape_outlines.system())
+    SystemSet::new().with_system(add_shape_outlines)
 }

--- a/debug/src/lib.rs
+++ b/debug/src/lib.rs
@@ -63,8 +63,8 @@ impl Plugin for DebugPlugin {
 
         app.insert_resource(self.0)
             .init_resource::<DebugEntityMap>()
-            .add_system_to_stage(CoreStage::Last, track_debug_entities.system())
-            .add_system_to_stage(CoreStage::Last, scale_debug_entities.system());
+            .add_system_to_stage(CoreStage::Last, track_debug_entities)
+            .add_system_to_stage(CoreStage::Last, scale_debug_entities);
     }
 }
 

--- a/examples/collision_shapes_in_child_entity.rs
+++ b/examples/collision_shapes_in_child_entity.rs
@@ -9,8 +9,8 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_plugin(PhysicsPlugin::default())
         .insert_resource(Gravity::from(Vec2::new(0.0, -600.0)))
-        .add_startup_system(spawn_ground_and_camera.system())
-        .add_startup_system(spawn.system())
+        .add_startup_system(spawn_ground_and_camera)
+        .add_startup_system(spawn)
         .run();
 }
 

--- a/examples/debug_2d.rs
+++ b/examples/debug_2d.rs
@@ -7,7 +7,7 @@ fn main() {
         .insert_resource(Gravity::from(Vec3::new(0., -98.1, 0.)))
         .add_plugins(DefaultPlugins)
         .add_plugin(PhysicsPlugin::default()) // Add the plugin
-        .add_startup_system(spawn.system())
+        .add_startup_system(spawn)
         .run();
 }
 

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -9,8 +9,8 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_plugin(PhysicsPlugin::default()) // Add the plugin
         .insert_resource(Gravity::from(Vec2::new(0.0, -600.0))) // Define the gravity
-        .add_startup_system(spawn.system())
-        .add_system(log_collisions.system())
+        .add_startup_system(spawn)
+        .add_system(log_collisions)
         .run();
 }
 

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -17,12 +17,12 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_plugin(PhysicsPlugin::default())
-        .add_startup_system(spawn_camera.system())
-        .add_startup_system(spawn_player.system())
-        .add_startup_system(spawn_enemy.system())
-        .add_system(handle_input.system())
-        .add_system(log_collisions.system())
-        .add_system(kill_enemy.system())
+        .add_startup_system(spawn_camera)
+        .add_startup_system(spawn_player)
+        .add_startup_system(spawn_enemy)
+        .add_system(handle_input)
+        .add_system(log_collisions)
+        .add_system(kill_enemy)
         .run();
 }
 

--- a/examples/layers.rs
+++ b/examples/layers.rs
@@ -15,7 +15,7 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_plugin(PhysicsPlugin::default()) // Add the plugin
         .insert_resource(Gravity::from(Vec2::new(0.0, -600.0))) // Define the gravity
-        .add_startup_system(spawn.system())
+        .add_startup_system(spawn)
         .run();
 }
 

--- a/examples/quickstart.rs
+++ b/examples/quickstart.rs
@@ -7,7 +7,7 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_plugin(PhysicsPlugin::default()) // Add the Heron plugin
         .insert_resource(Gravity::from(Vec3::new(0.0, -300.0, 0.0))) // Define gravity
-        .add_startup_system(spawn.system())
+        .add_startup_system(spawn)
         .run();
 }
 

--- a/examples/ray_casting.rs
+++ b/examples/ray_casting.rs
@@ -13,10 +13,10 @@ fn main() {
         })
         .add_plugins(DefaultPlugins)
         .add_plugin(PhysicsPlugin::default()) // Add the plugin
-        .add_startup_system(setup.system())
-        .add_system(ray_cast_from_center.system())
-        .add_system(shape_cast_from_center.system())
-        .add_system(move_targeter.system())
+        .add_startup_system(setup)
+        .add_system(ray_cast_from_center)
+        .add_system(shape_cast_from_center)
+        .add_system(move_targeter)
         .run();
 }
 

--- a/rapier/src/lib.rs
+++ b/rapier/src/lib.rs
@@ -99,71 +99,59 @@ impl Plugin for RapierPlugin {
 
 fn removal_stage() -> SystemStage {
     SystemStage::single_threaded()
-        .with_system(body::remove_invalids_after_components_removed.system())
-        .with_system(shape::remove_invalids_after_components_removed.system())
-        .with_system(body::remove_invalids_after_component_changed.system())
-        .with_system(shape::remove_invalids_after_component_changed.system())
+        .with_system(body::remove_invalids_after_components_removed)
+        .with_system(shape::remove_invalids_after_components_removed)
+        .with_system(body::remove_invalids_after_component_changed)
+        .with_system(shape::remove_invalids_after_component_changed)
 }
 
 fn update_rapier_world_stage() -> SystemStage {
     SystemStage::parallel()
         .with_system(
             bevy::transform::transform_propagate_system::transform_propagate_system
-                .system()
                 .label(InternalSystem::TransformPropagation),
         )
-        .with_system(
-            body::update_rapier_position
-                .system()
-                .after(InternalSystem::TransformPropagation),
-        )
-        .with_system(velocity::update_rapier_velocity.system())
-        .with_system(acceleration::update_rapier_force_and_torque.system())
-        .with_system(damping::update_rapier_damping.system())
-        .with_system(damping::reset_rapier_damping.system())
-        .with_system(shape::update_position.system())
-        .with_system(shape::update_collision_groups.system())
-        .with_system(shape::update_sensor_flag.system())
-        .with_system(shape::remove_sensor_flag.system())
-        .with_system(shape::reset_collision_groups.system())
+        .with_system(body::update_rapier_position.after(InternalSystem::TransformPropagation))
+        .with_system(velocity::update_rapier_velocity)
+        .with_system(acceleration::update_rapier_force_and_torque)
+        .with_system(damping::update_rapier_damping)
+        .with_system(damping::reset_rapier_damping)
+        .with_system(shape::update_position)
+        .with_system(shape::update_collision_groups)
+        .with_system(shape::update_sensor_flag)
+        .with_system(shape::remove_sensor_flag)
+        .with_system(shape::reset_collision_groups)
 }
 
 fn body_update_stage() -> SystemStage {
     SystemStage::single_threaded()
-        .with_run_criteria(heron_core::should_run.system())
-        .with_system(body::create.system())
+        .with_run_criteria(heron_core::should_run)
+        .with_system(body::create)
 }
 
 fn create_collider_stage() -> SystemStage {
     SystemStage::single_threaded()
-        .with_run_criteria(heron_core::should_run.system())
-        .with_system(shape::create.system())
+        .with_run_criteria(heron_core::should_run)
+        .with_system(shape::create)
 }
 
 fn step_systems() -> SystemSet {
     SystemSet::new()
-        .with_run_criteria(heron_core::should_run.system())
-        .with_system(
-            pipeline::update_integration_parameters
-                .system()
-                .before(PhysicsSystem::Events),
-        )
-        .with_system(pipeline::step.system().label(PhysicsSystem::Events))
+        .with_run_criteria(heron_core::should_run)
+        .with_system(pipeline::update_integration_parameters.before(PhysicsSystem::Events))
+        .with_system(pipeline::step.label(PhysicsSystem::Events))
         .with_system(
             body::update_bevy_transform
-                .system()
                 .label(PhysicsSystem::TransformUpdate)
                 .after(PhysicsSystem::Events),
         )
         .with_system(
             velocity::update_velocity_component
-                .system()
                 .label(PhysicsSystem::VelocityUpdate)
                 .after(PhysicsSystem::Events),
         )
         .with_system(
             velocity::update_rapier_velocity
-                .system()
                 .after(PhysicsSystem::Events)
                 .after(PhysicsSystem::VelocityUpdate),
         )

--- a/rapier/src/pipeline.rs
+++ b/rapier/src/pipeline.rs
@@ -747,7 +747,7 @@ mod tests {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
             .add_plugin(RapierPlugin)
-            .add_startup_system(setup.system());
+            .add_startup_system(setup);
 
         app
     }
@@ -784,7 +784,7 @@ mod tests {
         // Get the app
         let mut app = setup_ray_cast_test_app();
         // Add our system
-        app.add_system(ray_cast.system());
+        app.add_system(ray_cast);
 
         // Run the app for a couple of loops to make sure the setup is completed and the ray has been cast
         app.update();
@@ -811,7 +811,7 @@ mod tests {
         // Get the app
         let mut app = setup_ray_cast_test_app();
         // Add our system
-        app.add_system(ray_cast.system());
+        app.add_system(ray_cast);
 
         // Run the app for a couple of loops to make sure the setup is completed and the ray has been cast
         app.update();
@@ -862,7 +862,7 @@ mod tests {
         // Get the app
         let mut app = setup_ray_cast_test_app();
         // Add our system
-        app.add_system(ray_cast.system());
+        app.add_system(ray_cast);
 
         // Run the app for a couple of loops to make sure the setup is completed and the ray has been cast
         app.update();
@@ -897,7 +897,7 @@ mod tests {
         // Get the app
         let mut app = setup_ray_cast_test_app();
         // Add our system
-        app.add_system(ray_cast.system());
+        app.add_system(ray_cast);
 
         // Run the app for a couple of loops to make sure the setup is completed and the ray has been cast
         app.update();

--- a/rapier/tests/events.rs
+++ b/rapier/tests/events.rs
@@ -26,7 +26,7 @@ fn test_app() -> App {
         .add_plugin(RapierPlugin)
         .add_system_to_stage(
             bevy::app::CoreStage::PostUpdate,
-            bevy::transform::transform_propagate_system::transform_propagate_system.system(),
+            bevy::transform::transform_propagate_system::transform_propagate_system,
         );
     builder
 }


### PR DESCRIPTION
I just removed all `.system()` calls, no longer necessary after 0.6.