### PR TITLE
fix(collision-from-mesh): don't fail if there is no render plugin registered

### DIFF
--- a/core/src/collision_from_mesh.rs
+++ b/core/src/collision_from_mesh.rs
@@ -139,6 +139,13 @@ mod tests {
     }
 
     #[test]
+    fn dont_fail_without_render_plugin() {
+        let mut app = App::new();
+        app.add_system(pending_collision_system);
+        app.update();
+    }
+
+    #[test]
     fn pending_collision_assignes() {
         let mut app = App::new();
         app.add_plugin(HeadlessRenderPlugin)

--- a/core/src/collision_from_mesh.rs
+++ b/core/src/collision_from_mesh.rs
@@ -39,8 +39,12 @@ pub(super) fn pending_collision_system(
     added_scenes: Query<'_, '_, (Entity, &Children, &PendingConvexCollision)>,
     scene_elements: Query<'_, '_, &Children, Without<PendingConvexCollision>>,
     mesh_handles: Query<'_, '_, &Handle<Mesh>>,
-    meshes: Res<'_, Assets<Mesh>>,
+    meshes: Option<Res<'_, Assets<Mesh>>>,
 ) {
+    let meshes = match meshes {
+        None => return,
+        Some(m) => m,
+    };
     for (entity, children, pending_collision) in added_scenes.iter() {
         if generate_collision(
             &mut commands,


### PR DESCRIPTION
The `collision-from-mesh` feature (#190) would cause the plugins to fail if there is no mesh assets resource. 

That is especially problematic for testing, when one may have enabled the `collision-from-mesh` feature, but still want to avoid using the render plugin in tests.

This change makes sure the `collision-from-mesh` feature does not fail if there is no mesh asset resource. Obviously, without a mesh asset, no collision will be generated from meshes.

cc: @Shatur