### PR TITLE
feat: let `CollisionData::new` accept any implementation of `IntoIterator<Item=Vec2>`

### DIFF
--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -106,13 +106,13 @@ impl CollisionData {
         rigid_body_entity: Entity,
         collision_shape_entity: Entity,
         collision_layers: CollisionLayers,
-        normals: SmallVec<[Vec2; 1]>,
+        normals: impl IntoIterator<Item = Vec2>,
     ) -> Self {
         Self {
             rigid_body_entity,
             collision_shape_entity,
             collision_layers,
-            normals,
+            normals: normals.into_iter().collect(),
         }
     }
 

--- a/rapier/Cargo.toml
+++ b/rapier/Cargo.toml
@@ -24,6 +24,7 @@ rapier2d = { version = "0.11.1", optional = true }
 rapier3d = { version = "0.11.1", optional = true }
 fnv = "1.0"
 crossbeam = "0.8.0"
+smallvec = "1.8.0"
 
 [dev-dependencies]
 bevy = { version = "0.6.0", default-features = false }

--- a/rapier/Cargo.toml
+++ b/rapier/Cargo.toml
@@ -24,7 +24,6 @@ rapier2d = { version = "0.11.1", optional = true }
 rapier3d = { version = "0.11.1", optional = true }
 fnv = "1.0"
 crossbeam = "0.8.0"
-smallvec = "1.8.0"
 
 [dev-dependencies]
 bevy = { version = "0.6.0", default-features = false }

--- a/rapier/src/pipeline.rs
+++ b/rapier/src/pipeline.rs
@@ -8,7 +8,6 @@ use bevy::math::Quat;
 use bevy::math::Vec2;
 use bevy::math::Vec3;
 use crossbeam::channel::{Receiver, Sender};
-use smallvec::SmallVec;
 
 use heron_core::{
     CollisionData, CollisionEvent, CollisionLayers, CollisionShape, Gravity, PhysicsStepDuration,
@@ -477,30 +476,24 @@ impl EventManager {
                 collider1.parent().and_then(|parent| bodies.get(parent)),
                 collider2.parent().and_then(|parent| bodies.get(parent)),
             ) {
-                let normals1: SmallVec<[Vec2; 1]> = narrow_phase
-                    .contact_pair(h1, h2)
-                    .map(|contact_pair| {
-                        contact_pair
-                            .manifolds
-                            .iter()
-                            .map(|manifold| {
+                let normals1 =
+                    narrow_phase
+                        .contact_pair(h1, h2)
+                        .into_iter()
+                        .flat_map(|contact_pair| {
+                            contact_pair.manifolds.iter().map(|manifold| {
                                 Vec2::new(manifold.data.normal.x, manifold.data.normal.y)
                             })
-                            .collect()
-                    })
-                    .unwrap_or_default();
-                let normals2: SmallVec<[Vec2; 1]> = narrow_phase
-                    .contact_pair(h2, h1)
-                    .map(|contact_pair| {
-                        contact_pair
-                            .manifolds
-                            .iter()
-                            .map(|manifold| {
+                        });
+                let normals2 =
+                    narrow_phase
+                        .contact_pair(h2, h1)
+                        .into_iter()
+                        .flat_map(|contact_pair| {
+                            contact_pair.manifolds.iter().map(|manifold| {
                                 Vec2::new(manifold.data.normal.x, manifold.data.normal.y)
                             })
-                            .collect()
-                    })
-                    .unwrap_or_default();
+                        });
 
                 let d1 = CollisionData::new(
                     Entity::from_bits(rb1.user_data as u64),

--- a/rapier/src/pipeline.rs
+++ b/rapier/src/pipeline.rs
@@ -8,6 +8,7 @@ use bevy::math::Quat;
 use bevy::math::Vec2;
 use bevy::math::Vec3;
 use crossbeam::channel::{Receiver, Sender};
+use smallvec::SmallVec;
 
 use heron_core::{
     CollisionData, CollisionEvent, CollisionLayers, CollisionShape, Gravity, PhysicsStepDuration,
@@ -476,7 +477,7 @@ impl EventManager {
                 collider1.parent().and_then(|parent| bodies.get(parent)),
                 collider2.parent().and_then(|parent| bodies.get(parent)),
             ) {
-                let normals1 = narrow_phase
+                let normals1: SmallVec<[Vec2; 1]> = narrow_phase
                     .contact_pair(h1, h2)
                     .map(|contact_pair| {
                         contact_pair
@@ -488,7 +489,7 @@ impl EventManager {
                             .collect()
                     })
                     .unwrap_or_default();
-                let normals2 = narrow_phase
+                let normals2: SmallVec<[Vec2; 1]> = narrow_phase
                     .contact_pair(h2, h1)
                     .map(|contact_pair| {
                         contact_pair


### PR DESCRIPTION
Resolve #206 

*This may cause type inference problems*, but is nevertheless considered a minor change. 
This is because it can easily be mitigated *before* updating to the latest version by explicitly declaring the type instead of relying on the type inference.

Fore more information about why this type of change is considered minor see: https://github.com/rust-lang/rfcs/blob/master/text/1105-api-evolution.md#minor-change-generalizing-to-generics
