### PR TITLE
feat: implement Reflect for PendingConvexCollision

### DIFF
--- a/core/src/collision_from_mesh.rs
+++ b/core/src/collision_from_mesh.rs
@@ -25,7 +25,7 @@ use crate::{CollisionShape, RigidBody};
 ///         });
 /// }
 /// ```
-#[derive(Component)]
+#[derive(Component, Reflect)]
 pub struct PendingConvexCollision {
     /// Rigid body type which will be assigned to every scene entity.
     pub body_type: RigidBody,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -82,7 +82,8 @@ impl Plugin for CorePlugin {
             });
 
         #[cfg(feature = "collision-from-mesh")]
-        app.add_system(collision_from_mesh::pending_collision_system);
+        app.register_type::<PendingConvexCollision>()
+            .add_system(collision_from_mesh::pending_collision_system);
     }
 }
 


### PR DESCRIPTION
I noticed that all other Heron types implement `Reflect`. So I added it to `PendingConvexCollision`.