### PR TITLE
feat: colliding entities component

### DIFF
--- a/core/src/colliding_entities.rs
+++ b/core/src/colliding_entities.rs
@@ -2,7 +2,7 @@ use bevy::{prelude::*, utils::HashSet};
 
 use crate::CollisionEvent;
 
-/// Component which will be filled with a list of entities with which the current entity is currently in contact (if present).
+/// Component which will be filled (if present) with a list of entities with which the current entity is currently in contact.
 #[derive(Component, Default, Reflect)]
 pub struct CollidingEntities(pub HashSet<Entity>);
 
@@ -57,7 +57,10 @@ mod tests {
             .world
             .get_resource_mut::<Events<CollisionEvent>>()
             .unwrap();
-        collision_events.send(CollisionEvent::Started(collision_data1.clone(), collision_data2.clone()));
+        collision_events.send(CollisionEvent::Started(
+            collision_data1.clone(),
+            collision_data2.clone(),
+        ));
 
         app.update();
 
@@ -122,6 +125,5 @@ mod tests {
             0,
             "Colliding entity should be removed from the list when the collision ends"
         );
-
     }
 }

--- a/core/src/colliding_entities.rs
+++ b/core/src/colliding_entities.rs
@@ -1,0 +1,127 @@
+use bevy::{prelude::*, utils::HashSet};
+
+use crate::CollisionEvent;
+
+/// Component which will be filled with a list of entities with which the current entity is currently in contact (if present).
+#[derive(Component, Default, Reflect)]
+pub struct CollidingEntities(pub HashSet<Entity>);
+
+/// Adds entity to [`CollidingEntities`] on starting collision and removes from it when the
+/// collision end.
+pub(super) fn update_colliding_entities(
+    mut collision_events: EventReader<'_, '_, CollisionEvent>,
+    mut colliding_entities: Query<'_, '_, &mut CollidingEntities>,
+) {
+    for event in collision_events.iter() {
+        let (entity1, entity2) = event.rigid_body_entities();
+        if event.is_started() {
+            if let Ok(mut entities) = colliding_entities.get_mut(entity1) {
+                entities.0.insert(entity2);
+            }
+            if let Ok(mut entities) = colliding_entities.get_mut(entity2) {
+                entities.0.insert(entity1);
+            }
+        } else {
+            if let Ok(mut entities) = colliding_entities.get_mut(entity1) {
+                entities.0.remove(&entity2);
+            }
+            if let Ok(mut entities) = colliding_entities.get_mut(entity2) {
+                entities.0.remove(&entity1);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bevy::app::Events;
+
+    use crate::{CollisionData, CollisionLayers};
+
+    use super::*;
+
+    #[test]
+    fn colliding_entities_updates() {
+        let mut app = App::new();
+        app.add_event::<CollisionEvent>()
+            .add_system(update_colliding_entities);
+
+        let entity1 = app.world.spawn().insert(CollidingEntities::default()).id();
+        let entity2 = app.world.spawn().insert(CollidingEntities::default()).id();
+
+        let collision_data1 =
+            CollisionData::new(entity1, Entity::from_raw(0), CollisionLayers::default(), []);
+        let collision_data2 =
+            CollisionData::new(entity2, Entity::from_raw(0), CollisionLayers::default(), []);
+        let mut collision_events = app
+            .world
+            .get_resource_mut::<Events<CollisionEvent>>()
+            .unwrap();
+        collision_events.send(CollisionEvent::Started(collision_data1.clone(), collision_data2.clone()));
+
+        app.update();
+
+        let colliding_entities1 = app
+            .world
+            .entity(entity1)
+            .get::<CollidingEntities>()
+            .unwrap();
+        assert_eq!(
+            colliding_entities1.0.len(),
+            1,
+            "There should be one colliding entity"
+        );
+        assert_eq!(
+            colliding_entities1.0.iter().next().unwrap(),
+            &entity2,
+            "Colliding entity should be equal to second entity"
+        );
+
+        let colliding_entities2 = app
+            .world
+            .entity(entity2)
+            .get::<CollidingEntities>()
+            .unwrap();
+        assert_eq!(
+            colliding_entities2.0.len(),
+            1,
+            "There should be one colliding entity"
+        );
+        assert_eq!(
+            colliding_entities2.0.iter().next().unwrap(),
+            &entity1,
+            "Colliding entity should be equal to second entity"
+        );
+
+        let mut collision_events = app
+            .world
+            .get_resource_mut::<Events<CollisionEvent>>()
+            .unwrap();
+        collision_events.send(CollisionEvent::Stopped(collision_data1, collision_data2));
+
+        app.update();
+
+        let colliding_entities1 = app
+            .world
+            .entity(entity1)
+            .get::<CollidingEntities>()
+            .unwrap();
+        assert_eq!(
+            colliding_entities1.0.len(),
+            0,
+            "Colliding entity should be removed from the list when the collision ends"
+        );
+
+        let colliding_entities2 = app
+            .world
+            .entity(entity2)
+            .get::<CollidingEntities>()
+            .unwrap();
+        assert_eq!(
+            colliding_entities2.0.len(),
+            0,
+            "Colliding entity should be removed from the list when the collision ends"
+        );
+
+    }
+}

--- a/core/src/collisions.rs
+++ b/core/src/collisions.rs
@@ -26,8 +26,8 @@ impl Collisions {
     }
 
     /// An iterator visiting all colliding entities in arbitrary order.
-    pub fn iter(&self) -> impl Iterator<Item = &Entity> {
-        self.0.iter()
+    pub fn iter(&self) -> impl Iterator<Item = Entity> + '_ {
+        self.0.iter().copied()
     }
 }
 
@@ -107,7 +107,7 @@ mod tests {
         assert_eq!(collisions1.len(), 1, "There should be one colliding entity");
         assert_eq!(
             collisions1.iter().next().unwrap(),
-            &entity2,
+            entity2,
             "Colliding entity should be equal to the second entity"
         );
 
@@ -115,7 +115,7 @@ mod tests {
         assert_eq!(collisions2.len(), 1, "There should be one colliding entity");
         assert_eq!(
             collisions2.iter().next().unwrap(),
-            &entity1,
+            entity1,
             "Colliding entity should be equal to the first entity"
         );
 

--- a/core/src/collisions.rs
+++ b/core/src/collisions.rs
@@ -128,16 +128,14 @@ mod tests {
         app.update();
 
         let collisions1 = app.world.entity(entity1).get::<Collisions>().unwrap();
-        assert_eq!(
-            collisions1.len(),
-            0,
+        assert!(
+            collisions1.is_empty(),
             "Colliding entity should be removed from the Collisions component when the collision ends"
         );
 
         let collisions2 = app.world.entity(entity2).get::<Collisions>().unwrap();
-        assert_eq!(
-            collisions2.len(),
-            0,
+        assert!(
+            collisions2.is_empty(),
             "Colliding entity should be removed from the Collisions component when the collision ends"
         );
     }
@@ -160,9 +158,8 @@ mod tests {
         app.update();
 
         let collisions = app.world.entity(entity).get::<Collisions>().unwrap();
-        assert_eq!(
-            collisions.len(),
-            0,
+        assert!(
+            collisions.is_empty(),
             "Despawned entity should be removed from the Collisions component"
         );
     }

--- a/core/src/collisions.rs
+++ b/core/src/collisions.rs
@@ -8,16 +8,19 @@ pub struct Collisions(HashSet<Entity>);
 
 impl Collisions {
     /// Returns the number of colliding entities.
+    #[must_use]
     pub fn len(&self) -> usize {
         self.0.len()
     }
 
     /// Returns `true` if the collisions contains the specified entity.
+    #[must_use]
     pub fn contains(&self, entity: &Entity) -> bool {
         self.0.contains(entity)
     }
 
     /// An iterator visiting all colliding entities in arbitrary order.
+    #[must_use]
     pub fn iter(&self) -> impl Iterator<Item = &Entity> {
         self.0.iter()
     }

--- a/core/src/collisions.rs
+++ b/core/src/collisions.rs
@@ -13,6 +13,12 @@ impl Collisions {
         self.0.len()
     }
 
+    /// Returns `true` if there is no colliding entities.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
     /// Returns `true` if the collisions contains the specified entity.
     #[must_use]
     pub fn contains(&self, entity: &Entity) -> bool {
@@ -20,7 +26,6 @@ impl Collisions {
     }
 
     /// An iterator visiting all colliding entities in arbitrary order.
-    #[must_use]
     pub fn iter(&self) -> impl Iterator<Item = &Entity> {
         self.0.iter()
     }

--- a/core/src/collisions.rs
+++ b/core/src/collisions.rs
@@ -66,7 +66,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn collisions_update() {
+    fn collisions_updates() {
         let mut app = App::new();
         app.add_event::<CollisionEvent>()
             .add_system(update_collisions_system);
@@ -94,7 +94,7 @@ mod tests {
         assert_eq!(
             collisions1.iter().next().unwrap(),
             &entity2,
-            "Colliding entity should be equal to second entity"
+            "Colliding entity should be equal to the second entity"
         );
 
         let collisions2 = app.world.entity(entity2).get::<Collisions>().unwrap();
@@ -102,7 +102,7 @@ mod tests {
         assert_eq!(
             collisions2.iter().next().unwrap(),
             &entity1,
-            "Colliding entity should be equal to second entity"
+            "Colliding entity should be equal to the first entity"
         );
 
         let mut collision_events = app
@@ -117,14 +117,16 @@ mod tests {
         assert_eq!(
             collisions1.len(),
             0,
-            "Colliding entity should be removed from the list when the collision ends"
+            "Colliding entity should be removed from the Collisions component when the collision ends"
         );
 
         let collisions2 = app.world.entity(entity2).get::<Collisions>().unwrap();
         assert_eq!(
             collisions2.len(),
             0,
-            "Colliding entity should be removed from the list when the collision ends"
+            "Colliding entity should be removed from the Collisions component when the collision ends"
+        );
+    }
         );
     }
 }

--- a/core/src/collisions.rs
+++ b/core/src/collisions.rs
@@ -33,7 +33,7 @@ impl Collisions {
 
 /// Adds entity to [`CollidingEntities`] on starting collision and removes from it when the
 /// collision end.
-pub(super) fn update_collisions(
+pub(super) fn update_collisions_system(
     mut collision_events: EventReader<'_, '_, CollisionEvent>,
     mut collisions: Query<'_, '_, &mut Collisions>,
 ) {
@@ -69,7 +69,7 @@ mod tests {
     fn collisions_update() {
         let mut app = App::new();
         app.add_event::<CollisionEvent>()
-            .add_system(update_collisions);
+            .add_system(update_collisions_system);
 
         let entity1 = app.world.spawn().insert(Collisions::default()).id();
         let entity2 = app.world.spawn().insert(Collisions::default()).id();

--- a/core/src/collisions.rs
+++ b/core/src/collisions.rs
@@ -4,7 +4,24 @@ use crate::CollisionEvent;
 
 /// Component which will be filled (if present) with a list of entities with which the current entity is currently in contact.
 #[derive(Component, Default, Reflect)]
-pub struct Collisions(pub HashSet<Entity>);
+pub struct Collisions(HashSet<Entity>);
+
+impl Collisions {
+    /// Returns the number of colliding entities.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns `true` if the collisions contains the specified entity.
+    pub fn contains(&self, entity: &Entity) -> bool {
+        self.0.contains(entity)
+    }
+
+    /// An iterator visiting all colliding entities in arbitrary order.
+    pub fn iter(&self) -> impl Iterator<Item = &Entity> {
+        self.0.iter()
+    }
+}
 
 /// Adds entity to [`CollidingEntities`] on starting collision and removes from it when the
 /// collision end.
@@ -65,25 +82,17 @@ mod tests {
         app.update();
 
         let collisions1 = app.world.entity(entity1).get::<Collisions>().unwrap();
+        assert_eq!(collisions1.len(), 1, "There should be one colliding entity");
         assert_eq!(
-            collisions1.0.len(),
-            1,
-            "There should be one colliding entity"
-        );
-        assert_eq!(
-            collisions1.0.iter().next().unwrap(),
+            collisions1.iter().next().unwrap(),
             &entity2,
             "Colliding entity should be equal to second entity"
         );
 
         let collisions2 = app.world.entity(entity2).get::<Collisions>().unwrap();
+        assert_eq!(collisions2.len(), 1, "There should be one colliding entity");
         assert_eq!(
-            collisions2.0.len(),
-            1,
-            "There should be one colliding entity"
-        );
-        assert_eq!(
-            collisions2.0.iter().next().unwrap(),
+            collisions2.iter().next().unwrap(),
             &entity1,
             "Colliding entity should be equal to second entity"
         );
@@ -98,14 +107,14 @@ mod tests {
 
         let collisions1 = app.world.entity(entity1).get::<Collisions>().unwrap();
         assert_eq!(
-            collisions1.0.len(),
+            collisions1.len(),
             0,
             "Colliding entity should be removed from the list when the collision ends"
         );
 
         let collisions2 = app.world.entity(entity2).get::<Collisions>().unwrap();
         assert_eq!(
-            collisions2.0.len(),
+            collisions2.len(),
             0,
             "Colliding entity should be removed from the list when the collision ends"
         );

--- a/core/src/collisions.rs
+++ b/core/src/collisions.rs
@@ -59,7 +59,7 @@ pub(super) fn update_collisions_system(
 
 /// Removes deleted entities from [`Collisions`] component because
 /// entity deletion doesn't emit [`CollisionEvent::Stopped`].
-/// It's an upstream issue, see https://github.com/dimforge/rapier/issues/299.
+/// It's an upstream [issue](https://github.com/dimforge/rapier/issues/299).
 pub(super) fn cleanup_collisions_system(
     removed_rigid_bodies: RemovedComponents<'_, RigidBody>,
     mut collisions: Query<'_, '_, &mut Collisions>,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -80,6 +80,7 @@ impl Plugin for CorePlugin {
             .register_type::<SensorShape>()
             .register_type::<Collisions>()
             .add_system(collisions::update_collisions_system)
+            .add_system_to_stage(CoreStage::PostUpdate, collisions::cleanup_collisions_system)
             .add_system_to_stage(CoreStage::First, PhysicsSteps::update)
             .add_stage_before(CoreStage::PostUpdate, crate::stage::ROOT, {
                 Schedule::default().with_stage(crate::stage::UPDATE, SystemStage::parallel())

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use bevy::ecs::schedule::ShouldRun;
 use bevy::prelude::*;
 
-use colliding_entities::CollidingEntities;
+pub use colliding_entities::CollidingEntities;
 #[cfg(feature = "collision-from-mesh")]
 pub use collision_from_mesh::PendingConvexCollision;
 pub use constraints::RotationConstraints;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -10,9 +10,9 @@ use std::sync::Arc;
 use bevy::ecs::schedule::ShouldRun;
 use bevy::prelude::*;
 
-pub use colliding_entities::CollidingEntities;
 #[cfg(feature = "collision-from-mesh")]
 pub use collision_from_mesh::PendingConvexCollision;
+pub use collisions::Collisions;
 pub use constraints::RotationConstraints;
 pub use events::{CollisionData, CollisionEvent};
 pub use gravity::Gravity;
@@ -21,9 +21,9 @@ pub use physics_time::PhysicsTime;
 pub use step::{PhysicsStepDuration, PhysicsSteps};
 pub use velocity::{Acceleration, AxisAngle, Damping, Velocity};
 
-mod colliding_entities;
 #[cfg(feature = "collision-from-mesh")]
 mod collision_from_mesh;
+mod collisions;
 mod constraints;
 mod events;
 mod gravity;
@@ -78,8 +78,8 @@ impl Plugin for CorePlugin {
             .register_type::<RotationConstraints>()
             .register_type::<CollisionLayers>()
             .register_type::<SensorShape>()
-            .register_type::<CollidingEntities>()
-            .add_system(colliding_entities::update_colliding_entities)
+            .register_type::<Collisions>()
+            .add_system(collisions::update_collisions)
             .add_system_to_stage(CoreStage::First, PhysicsSteps::update)
             .add_stage_before(CoreStage::PostUpdate, crate::stage::ROOT, {
                 Schedule::default().with_stage(crate::stage::UPDATE, SystemStage::parallel())

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 use bevy::ecs::schedule::ShouldRun;
 use bevy::prelude::*;
 
+use colliding_entities::CollidingEntities;
 #[cfg(feature = "collision-from-mesh")]
 pub use collision_from_mesh::PendingConvexCollision;
 pub use constraints::RotationConstraints;
@@ -20,6 +21,7 @@ pub use physics_time::PhysicsTime;
 pub use step::{PhysicsStepDuration, PhysicsSteps};
 pub use velocity::{Acceleration, AxisAngle, Damping, Velocity};
 
+mod colliding_entities;
 #[cfg(feature = "collision-from-mesh")]
 mod collision_from_mesh;
 mod constraints;
@@ -76,6 +78,8 @@ impl Plugin for CorePlugin {
             .register_type::<RotationConstraints>()
             .register_type::<CollisionLayers>()
             .register_type::<SensorShape>()
+            .register_type::<CollidingEntities>()
+            .add_system(colliding_entities::update_colliding_entities)
             .add_system_to_stage(CoreStage::First, PhysicsSteps::update)
             .add_stage_before(CoreStage::PostUpdate, crate::stage::ROOT, {
                 Schedule::default().with_stage(crate::stage::UPDATE, SystemStage::parallel())

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -79,7 +79,7 @@ impl Plugin for CorePlugin {
             .register_type::<CollisionLayers>()
             .register_type::<SensorShape>()
             .register_type::<Collisions>()
-            .add_system(collisions::update_collisions)
+            .add_system(collisions::update_collisions_system)
             .add_system_to_stage(CoreStage::First, PhysicsSteps::update)
             .add_stage_before(CoreStage::PostUpdate, crate::stage::ROOT, {
                 Schedule::default().with_stage(crate::stage::UPDATE, SystemStage::parallel())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,9 +146,9 @@ pub mod prelude {
 
     #[allow(deprecated)]
     pub use crate::{
-        stage, Acceleration, AxisAngle, CollisionEvent, CollisionLayers, CollisionShape, Damping,
-        Gravity, PhysicMaterial, PhysicsLayer, PhysicsPlugin, PhysicsSystem, PhysicsTime,
-        RigidBody, RotationConstraints, Velocity,
+        stage, Acceleration, AxisAngle, CollisionEvent, CollisionLayers, CollisionShape,
+        Collisions, Damping, Gravity, PhysicMaterial, PhysicsLayer, PhysicsPlugin, PhysicsSystem,
+        PhysicsTime, RigidBody, RotationConstraints, Velocity,
     };
 }
 


### PR DESCRIPTION
Closes #207.

I added a component that automatically filled with colliding object entities.

Things to discuss:
* I used `CollidingEntities` because the suggested `Collision` could be confusing (and [already used in Bevy](https://docs.rs/bevy/latest/bevy/sprite/collide_aabb/enum.Collision.html), but not in prelude). Is this okay name?
* Should we provide `Deref` for `CollidingEntities`?