### PR TITLE
refactor: cleanup unused dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ heron_debug = { version = "2.2.0", path = "debug", optional = true }
 bevy = { version = "0.6.0", default-features = false }
 
 [dev-dependencies]
-bevy = { version = "0.6.0", default-features = false, features=["render", "x11"] }
+bevy = { version = "0.6.0", default-features = false, features=["bevy_sprite", "bevy_render", "bevy_core_pipeline", "x11"] }
 rstest = "0.12"
 
 [build-dependencies]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,7 +14,7 @@ all-features = true
 [features]
 default = []
 3d = []
-collision-from-mesh = ["bevy/render"]
+collision-from-mesh = ["bevy/bevy_render"]
 
 [dependencies]
 bevy = { version = "0.6.0", default-features = false }
@@ -23,7 +23,6 @@ smallvec = "1.8"
 
 [dev-dependencies]
 rstest = "0.12"
-bevy = { version = "0.6.0", default-features = false, features = ["render"] }
 
 [build-dependencies]
 cfg_aliases = "0.1.1"

--- a/debug/Cargo.toml
+++ b/debug/Cargo.toml
@@ -16,7 +16,7 @@ default = []
 [dependencies]
 heron_core = { version = "2.2.0", path = "../core" }
 heron_rapier = { version = "2.2.0", path = "../rapier" }
-bevy = { version = "0.6.0", default-features = false, features = ["render"] }
+bevy = { version = "0.6.0", default-features = false, features = ["bevy_render"] }
 bevy_prototype_lyon = { version = "0.4.0", optional = true }
 lyon_path = { version = "0.17.4", optional = true }
 fnv = "1.0"

--- a/rapier/Cargo.toml
+++ b/rapier/Cargo.toml
@@ -26,7 +26,6 @@ fnv = "1.0"
 crossbeam = "0.8.0"
 
 [dev-dependencies]
-bevy = { version = "0.6.0", default-features = false }
 rstest = "0.12"
 
 [build-dependencies]


### PR DESCRIPTION
Previously used `render` feature is a [group](
https://github.com/bevyengine/bevy/blob/a291b5aaedb4affcb31df2e2e63cb0c665ffb24a/Cargo.toml#L35-L43) that contains unneeded stuff, like `bevy_ui` or `bevy_text`. Specified features in this PR is the required minimum. You can read more about in in this issue: https://github.com/bevyengine/bevy/issues/4202