### PR TITLE
feat: expose CollisionData in Collisions component

### DIFF
--- a/core/src/collisions.rs
+++ b/core/src/collisions.rs
@@ -1,10 +1,10 @@
-use bevy::{prelude::*, utils::HashSet};
+use bevy::{prelude::*, utils::HashMap};
 
-use crate::{CollisionEvent, RigidBody};
+use crate::{CollisionData, CollisionEvent, RigidBody};
 
 /// Component which will be filled (if present) with a list of entities with which the current entity is currently in contact.
 #[derive(Component, Default, Reflect)]
-pub struct Collisions(HashSet<Entity>);
+pub struct Collisions(HashMap<Entity, CollisionData>);
 
 impl Collisions {
     /// Returns the number of colliding entities.
@@ -22,12 +22,24 @@ impl Collisions {
     /// Returns `true` if the collisions contains the specified entity.
     #[must_use]
     pub fn contains(&self, entity: &Entity) -> bool {
-        self.0.contains(entity)
+        self.0.contains_key(entity)
     }
 
     /// An iterator visiting all colliding entities in arbitrary order.
+    #[deprecated(note = "Please use `entities()` instead")]
+    #[doc(hidden)]
     pub fn iter(&self) -> impl Iterator<Item = Entity> + '_ {
-        self.0.iter().copied()
+        self.entities()
+    }
+
+    /// An iterator visiting all colliding entities in arbitrary order.
+    pub fn entities(&self) -> impl Iterator<Item = Entity> + '_ {
+        self.0.keys().copied()
+    }
+
+    /// An iterator visiting all data from colliding entities in arbitrary order.
+    pub fn collision_data(&self) -> impl Iterator<Item = &CollisionData> + '_ {
+        self.0.values()
     }
 }
 
@@ -38,13 +50,14 @@ pub(super) fn update_collisions_system(
     mut collisions: Query<'_, '_, &mut Collisions>,
 ) {
     for event in collision_events.iter() {
-        let (entity1, entity2) = event.rigid_body_entities();
+        let (data1, data2) = event.clone().data();
+        let (entity1, entity2) = (data1.rigid_body_entity(), data2.rigid_body_entity());
         if event.is_started() {
             if let Ok(mut entities) = collisions.get_mut(entity1) {
-                entities.0.insert(entity2);
+                entities.0.insert(entity2, data2);
             }
             if let Ok(mut entities) = collisions.get_mut(entity2) {
-                entities.0.insert(entity1);
+                entities.0.insert(entity1, data1);
             }
         } else {
             if let Ok(mut entities) = collisions.get_mut(entity1) {
@@ -106,17 +119,29 @@ mod tests {
         let collisions1 = app.world.entity(entity1).get::<Collisions>().unwrap();
         assert_eq!(collisions1.len(), 1, "There should be one colliding entity");
         assert_eq!(
-            collisions1.iter().next().unwrap(),
+            collisions1.entities().next().unwrap(),
             entity2,
             "Colliding entity should be equal to the second entity"
+        );
+
+        assert_eq!(
+            collisions1.collision_data().next().unwrap(),
+            &collision_data2,
+            "Colliding entity data should be equal to the second collision data"
         );
 
         let collisions2 = app.world.entity(entity2).get::<Collisions>().unwrap();
         assert_eq!(collisions2.len(), 1, "There should be one colliding entity");
         assert_eq!(
-            collisions2.iter().next().unwrap(),
+            collisions2.entities().next().unwrap(),
             entity1,
             "Colliding entity should be equal to the first entity"
+        );
+
+        assert_eq!(
+            collisions2.collision_data().next().unwrap(),
+            &collision_data1,
+            "Colliding entity data should be equal to the first collision data"
         );
 
         let mut collision_events = app
@@ -148,7 +173,15 @@ mod tests {
 
         let removing_entity = app.world.spawn().insert(RigidBody::Static).id();
         let mut collisions = Collisions::default();
-        collisions.0.insert(removing_entity);
+        collisions.0.insert(
+            removing_entity,
+            CollisionData::new(
+                removing_entity,
+                Entity::from_raw(0),
+                CollisionLayers::default(),
+                [],
+            ),
+        );
         let entity = app.world.spawn().insert(collisions).id();
 
         app.update();

--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -1,4 +1,4 @@
-use bevy::{ecs::entity::Entity, math::Vec2};
+use bevy::{ecs::entity::Entity, math::Vec2, prelude::Reflect};
 use smallvec::SmallVec;
 
 use crate::CollisionLayers;
@@ -33,7 +33,7 @@ pub enum CollisionEvent {
 }
 
 /// Collision data concerning one of the two entity that collided
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Reflect)]
 pub struct CollisionData {
     rigid_body_entity: Entity,
     collision_shape_entity: Entity,


### PR DESCRIPTION
Currently the `Collisions` component only exposes the entities present in a collision, but there is additional useful information available, such as the collision normals. This change exposes the `CollisionData` object in the `Collisions` component.

Additionally, the collision normals were captured as `Vec2`s, dropping the Z component. I swapped to a `Vec3`, zeroing the Z component when in 2D.