### PR TITLE
docs: fix inaccurate parameter documentation of `shape_cast`

### DIFF
--- a/rapier/src/pipeline.rs
+++ b/rapier/src/pipeline.rs
@@ -141,8 +141,8 @@ mod physics_world {
         ///
         /// - `shape`: The [`CollisionShape`] to use for the shape cast
         /// - `start_position`: The position to start the shape cast at
-        /// - `rotation`: The rotation of the collision shape
-        /// - `end_posiion`: The end position of the shape cast
+        /// - `start_rotation`: The rotation of the collision shape
+        /// - `ray`: A vector indicating the direction and the distance to cast the shape
         ///
         /// # Panics
         ///


### PR DESCRIPTION
The docs for `shape_cast` say `end_position` instead of `ray`, but the internal usage of the parameter is a ray, not the end position of the shape. This is consistent with the docs for `cast_ray`.

Big thanks to @mijalk0 for helping me figure this out. (Because it said `end_position` I thought I needed to pass the end position of the shape cast)