### PR TITLE
docs(readme): amend comparison to `bevy_rapier` in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,6 @@ It *will* be increased to the latest stable version in a major release. (even if
 Here are some key differences between the two projects:
 
 * `heron` tries to provide a smaller, simpler API that is easier to use. `bevy_rapier` is more complete and powerful, but a bit more complex.
-* `heron` mostly hides the underlying physics engine, so you don't have to use [rapier] directly nor [nalgebra]. `bevy_rapier` asks the user to deal directly with `rapier` and `nalgebra`.
 * `heron` is focused on games only. `bevy_rapier` targets all kind of physics simulation applications (incl. games).
 * `bevy_rapier` is actively maintained by [dimforge], the developer of `rapier`. `heron` is also active, but cannot evolve as fast as `bevy_rapier` can. 
 


### PR DESCRIPTION
Remove comment about `nalgebra` and `rapier` from comparison to `bevy_rapier`.

There may still be parts of `bevy_rapier` that expose `nalgebra`/`rapier` but I could not find an API that that `heron` also has that does.
At the very least I don't think this line accurately represents the current state of `bevy_rapier`'s API :)

Looking at the examples of [heron](https://github.com/jcornaz/heron/blob/alpha/examples/demo.rs#L56-L65) and [bevy_rapier](https://github.com/dimforge/bevy_rapier/blob/master/bevy_rapier3d/examples/boxes3.rs#L76-L78) it also seems like the basic API of `bevy_rapier` is not more complicated that `heron`'s at this time.
