### PR TITLE
chore(deps): update to bevy 0.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
 
 env:
-  RUST_VERSION: 1.60.0
+  RUST_VERSION: 1.62.1
   RUSTFLAGS: "-D warnings"
   RUSTDOCFLAGS: "-D warnings"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,10 +30,10 @@ heron_core = { version = "3.0.0", path = "core" }
 heron_macros = { version = "3.0.0", path = "macros" }
 heron_rapier = { version = "3.0.0", path = "rapier" }
 heron_debug = { version = "3.0.0", path = "debug", optional = true }
-bevy = { version = "0.7.0", default-features = false }
+bevy = { version = "0.8.0", default-features = false }
 
 [dev-dependencies]
-bevy = { version = "0.7.0", default-features = false, features=["bevy_sprite", "bevy_render", "bevy_core_pipeline", "x11", "bevy_pbr"] }
+bevy = { version = "0.8.0", default-features = false, features=["bevy_sprite", "bevy_render", "bevy_core_pipeline", "x11", "bevy_pbr"] }
 rstest = "0.13"
 
 [build-dependencies]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,10 +14,10 @@ all-features = true
 [features]
 default = []
 3d = []
-collision-from-mesh = ["bevy/bevy_render"]
+collision-from-mesh = ["bevy/bevy_render", "bevy/bevy_scene", "bevy/bevy_asset"]
 
 [dependencies]
-bevy = { version = "0.7.0", default-features = false }
+bevy = { version = "0.8.0", default-features = false }
 duplicate = "0.4.1"
 smallvec = "1.8"
 

--- a/core/src/collision_from_mesh.rs
+++ b/core/src/collision_from_mesh.rs
@@ -21,8 +21,9 @@ use crate::{CollisionLayers, CollisionShape, RigidBody};
 ///         .insert(PendingConvexCollision::default())
 ///         .insert(RigidBody::Static)
 ///         .insert(CollisionLayers::default())
-///         .with_children(|parent| {
-///             parent.spawn_scene(asset_server.load("cubes.glb#Scene0"));
+///         .insert_bundle(SceneBundle {
+///             scene: asset_server.load("cubes.glb#Scene0"),
+///             ..default()
 ///         });
 /// }
 /// ```

--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -1,4 +1,4 @@
-use bevy::{ecs::entity::Entity, math::Vec3, prelude::Reflect};
+use bevy::{ecs::entity::Entity, math::Vec3, prelude::Reflect, reflect::FromReflect};
 use smallvec::SmallVec;
 
 use crate::CollisionLayers;
@@ -33,7 +33,7 @@ pub enum CollisionEvent {
 }
 
 /// Collision data concerning one of the two entity that collided
-#[derive(Debug, Clone, PartialEq, Reflect)]
+#[derive(Debug, Clone, PartialEq, Reflect, FromReflect)]
 pub struct CollisionData {
     rigid_body_entity: Entity,
     collision_shape_entity: Entity,

--- a/core/src/layers.rs
+++ b/core/src/layers.rs
@@ -1,4 +1,7 @@
-use bevy::{ecs::component::Component, reflect::Reflect};
+use bevy::{
+    ecs::component::Component,
+    reflect::{FromReflect, Reflect},
+};
 
 /// Describes a collision layer
 ///
@@ -71,7 +74,7 @@ impl<T: PhysicsLayer> PhysicsLayer for &T {
 ///         );
 /// }
 /// ```
-#[derive(Debug, Component, Copy, Clone, Eq, PartialEq, Reflect)]
+#[derive(Debug, Component, Copy, Clone, Eq, PartialEq, Reflect, FromReflect)]
 pub struct CollisionLayers {
     groups: u32,
     masks: u32,

--- a/debug/Cargo.toml
+++ b/debug/Cargo.toml
@@ -16,11 +16,11 @@ default = []
 [dependencies]
 heron_core = { version = "3.0.0", path = "../core" }
 heron_rapier = { version = "3.0.0", path = "../rapier" }
-bevy = { version = "0.7.0", default-features = false, features = ["bevy_render"] }
-bevy_prototype_lyon = { version = "0.5.0", optional = true }
+bevy = { version = "0.8.0", default-features = false, features = ["bevy_render"] }
+bevy_prototype_lyon = { version = "0.6.0", optional = true }
 lyon_path = { version = "0.17.7", optional = true }
 fnv = "1.0"
-bevy_prototype_debug_lines = { version = "0.7.1", default-features = false, optional = true }
+bevy_prototype_debug_lines = { version = "0.8.0", default-features = false, optional = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/debug/src/dim2.rs
+++ b/debug/src/dim2.rs
@@ -129,7 +129,7 @@ fn create_shape(
         }),
         Transform {
             translation: Vec3::Z,
-            scale: transform.scale.recip(),
+            scale: transform.to_scale_rotation_translation().0.recip(),
             ..Default::default()
         },
     )

--- a/debug/src/dim3.rs
+++ b/debug/src/dim3.rs
@@ -25,8 +25,10 @@ fn add_shape_outlines(
     mut lines: ResMut<'_, DebugLines>,
 ) {
     for (shape, trans, rigid_body_option, sensor_option) in shapes.iter() {
-        let origin = trans.translation;
-        let orient = trans.rotation;
+        let (_, global_rotation, global_translation) = trans.to_scale_rotation_translation();
+        let origin = global_translation;
+        let orient = global_rotation;
+
         let color = color.for_collider_type(rigid_body_option, sensor_option.is_some());
         match shape {
             CollisionShape::Cuboid {

--- a/debug/src/lib.rs
+++ b/debug/src/lib.rs
@@ -9,7 +9,7 @@
 
 //! Rendering of Heron's collision shapes for debugging purposes
 
-use bevy::prelude::*;
+use bevy::{math::Affine3A, prelude::*};
 use fnv::FnvHashMap;
 
 #[cfg(any(feature = "2d", feature = "3d"))]
@@ -126,16 +126,21 @@ fn scale_debug_entities(
     query
         .iter_mut()
         .filter(|(_, global)| {
-            let scale = global.scale;
+            let (scale, _, _) = global.to_scale_rotation_translation();
             !is_near(scale.x, 1.0) || !is_near(scale.y, 1.0)
         })
         .for_each(|(local, mut global)| {
+            let (global_scale, global_rotation, global_translation) =
+                global.to_scale_rotation_translation();
             if let Some(mut local) = local {
-                local.scale *= global.scale.recip();
+                local.scale *= global_scale.recip();
             }
-            global.scale.x = 1.0;
-            global.scale.y = 1.0;
-            global.scale.z = 1.0;
+
+            *global = GlobalTransform::from(Affine3A::from_scale_rotation_translation(
+                Vec3::ONE,
+                global_rotation,
+                global_translation,
+            ));
         });
 }
 

--- a/deny.toml
+++ b/deny.toml
@@ -12,6 +12,7 @@ copyleft = "deny"
 allow = [
     "Unlicense",
     "MIT",
+    "MIT-0",
     "BSD-3-Clause",
     "Apache-2.0",
     "Zlib",

--- a/examples/collision_shapes_in_child_entity.rs
+++ b/examples/collision_shapes_in_child_entity.rs
@@ -64,7 +64,7 @@ fn spawn(mut commands: Commands) {
 }
 
 fn spawn_ground_and_camera(mut commands: Commands) {
-    commands.spawn_bundle(OrthographicCameraBundle::new_2d());
+    commands.spawn_bundle(Camera2dBundle::default());
 
     commands.spawn_bundle((
         Transform::from_translation(Vec3::new(0.0, -300.0, 0.0)),

--- a/examples/debug_2d.rs
+++ b/examples/debug_2d.rs
@@ -12,7 +12,7 @@ fn main() {
 }
 
 fn spawn(mut commands: Commands) {
-    commands.spawn_bundle(OrthographicCameraBundle::new_2d());
+    commands.spawn_bundle(Camera2dBundle::default());
 
     // Sphere
     commands

--- a/examples/debug_3d.rs
+++ b/examples/debug_3d.rs
@@ -32,15 +32,13 @@ fn setup(
             ],
         });
 
-    commands
-        .spawn_bundle(PerspectiveCameraBundle::new_3d())
-        .insert(
-            Transform {
-                translation: Vec3::new(3.0, 7., -19.0),
-                ..Default::default()
-            }
-            .looking_at(Vec3::new(1., 4., 0.), Vec3::Y),
-        );
+    commands.spawn_bundle(Camera3dBundle::default()).insert(
+        Transform {
+            translation: Vec3::new(3.0, 7., -19.0),
+            ..Default::default()
+        }
+        .looking_at(Vec3::new(1., 4., 0.), Vec3::Y),
+    );
 
     // Cube (with radius)
     commands

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -15,7 +15,7 @@ fn main() {
 }
 
 fn spawn(mut commands: Commands) {
-    commands.spawn_bundle(OrthographicCameraBundle::new_2d());
+    commands.spawn_bundle(Camera2dBundle::default());
 
     // The ground
     let size = Vec2::new(1000.0, 50.0);

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -116,7 +116,7 @@ fn spawn_enemy(mut commands: Commands) {
 }
 
 fn spawn_camera(mut commands: Commands) {
-    commands.spawn_bundle(OrthographicCameraBundle::new_2d());
+    commands.spawn_bundle(Camera2dBundle::default());
 }
 
 fn handle_input(input: Res<Input<KeyCode>>, mut players: Query<&mut Velocity, With<Player>>) {

--- a/examples/layers.rs
+++ b/examples/layers.rs
@@ -20,7 +20,7 @@ fn main() {
 }
 
 fn spawn(mut commands: Commands) {
-    commands.spawn_bundle(OrthographicCameraBundle::new_2d());
+    commands.spawn_bundle(Camera2dBundle::default());
 
     let size = Vec2::new(1000.0, 50.0);
     let mut ground_entity = commands.spawn();

--- a/examples/quickstart.rs
+++ b/examples/quickstart.rs
@@ -13,7 +13,7 @@ fn main() {
 
 fn spawn(mut commands: Commands) {
     // Ensure we can see things
-    commands.spawn_bundle(OrthographicCameraBundle::new_2d());
+    commands.spawn_bundle(Camera2dBundle::default());
 
     // the size of our sprite
     let size = Vec2::new(30.0, 30.0);

--- a/examples/ray_casting.rs
+++ b/examples/ray_casting.rs
@@ -29,7 +29,7 @@ struct Targeter;
 struct ShapeCastIgnored;
 
 fn setup(mut commands: Commands) {
-    commands.spawn_bundle(OrthographicCameraBundle::new_2d());
+    commands.spawn_bundle(Camera2dBundle::default());
 
     // Spawn some walls to cast rays at
     for (size, pos) in &[

--- a/rapier/Cargo.toml
+++ b/rapier/Cargo.toml
@@ -19,7 +19,7 @@ enhanced-determinism = ["rapier2d?/enhanced-determinism", "rapier3d?/enhanced-de
 
 [dependencies]
 heron_core = { version = "3.0.0", path = "../core" }
-bevy = { version = "0.7.0", default-features = false }
+bevy = { version = "0.8.0", default-features = false }
 rapier2d = { version = "0.13.0", optional = true }
 rapier3d = { version = "0.13.0", optional = true }
 fnv = "1.0"

--- a/rapier/src/body.rs
+++ b/rapier/src/body.rs
@@ -1,4 +1,5 @@
 use bevy::ecs::prelude::*;
+use bevy::math::Affine3A;
 use bevy::transform::prelude::*;
 use fnv::FnvHashMap;
 
@@ -33,9 +34,10 @@ pub(crate) fn create(
     >,
 ) {
     for (entity, transform, body, velocity, damping, rotation_constraints) in query.iter() {
+        let (_, global_rotation, global_translation) = transform.to_scale_rotation_translation();
         let mut builder = RigidBodyBuilder::new(body_status(*body))
             .user_data(entity.to_bits().into())
-            .position((transform.translation, transform.rotation).into_rapier());
+            .position((global_translation, global_rotation).into_rapier());
 
         #[allow(unused_variables)]
         if let Some(RotationConstraints {
@@ -192,7 +194,10 @@ pub(crate) fn update_rapier_position(
 ) {
     for (transform, handle) in query.iter() {
         if let Some(body) = bodies.get_mut(handle.0) {
-            let isometry = (transform.translation, transform.rotation).into_rapier();
+            let (_, global_rotation, global_translation) =
+                transform.to_scale_rotation_translation();
+            let isometry = (global_translation, global_rotation).into_rapier();
+
             if body.is_kinematic() {
                 body.set_next_kinematic_position(isometry);
             } else {
@@ -230,33 +235,39 @@ pub(crate) fn update_bevy_transform(
         #[cfg(dim2)]
         let (mut translation, rotation) = body.position().into_bevy();
 
+        let (global_scale, global_rotation, global_translation) =
+            global.to_scale_rotation_translation();
+
         #[cfg(dim2)]
         {
             // In 2D, preserve the transform `z` component that may have been set by the user
-            translation.z = global.translation.z;
+            translation.z = global_translation.z;
         }
 
-        if translation == global.translation && rotation == global.rotation {
+        if translation == global_translation && rotation == global_rotation {
             continue;
         }
 
         if let Some(local) = &mut local {
-            if local.translation == global.translation {
+            if local.translation == global_translation {
                 local.translation = translation;
             } else {
-                local.translation = translation - (global.translation - local.translation);
+                local.translation = translation - (global_translation - local.translation);
             }
 
-            if local.rotation == global.rotation {
+            if local.rotation == global_rotation {
                 local.rotation = rotation;
             } else {
                 local.rotation =
-                    rotation * (global.rotation * local.rotation.conjugate()).conjugate();
+                    rotation * (global_rotation * local.rotation.conjugate()).conjugate();
             }
         }
 
-        global.translation = translation;
-        global.rotation = rotation;
+        *global = GlobalTransform::from(Affine3A::from_scale_rotation_translation(
+            global_scale,
+            rotation,
+            translation,
+        ));
     }
 }
 

--- a/rapier/src/lib.rs
+++ b/rapier/src/lib.rs
@@ -23,6 +23,7 @@ pub extern crate rapier3d;
 
 use bevy::ecs::component::Component;
 use bevy::prelude::*;
+use bevy::time::TimePlugin;
 use bevy::transform::TransformSystem;
 #[cfg(dim2)]
 pub(crate) use rapier2d as rapier;
@@ -70,6 +71,7 @@ pub struct ColliderHandle(geometry::ColliderHandle);
 impl Plugin for RapierPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugin(heron_core::CorePlugin)
+            .add_plugin(TimePlugin)
             .init_resource::<PhysicsPipeline>()
             .init_resource::<body::HandleMap>()
             .init_resource::<shape::HandleMap>()
@@ -198,7 +200,10 @@ mod tests {
             app.update();
 
             assert_eq!(
-                app.world.get::<GlobalTransform>(child).unwrap().translation,
+                app.world
+                    .get::<GlobalTransform>(child)
+                    .unwrap()
+                    .translation(),
                 Vec3::X
             );
         }

--- a/rapier/src/pipeline.rs
+++ b/rapier/src/pipeline.rs
@@ -333,7 +333,7 @@ pub struct ShapeCastCollisionInfo {
 pub(crate) fn update_integration_parameters(
     physics_steps: Res<'_, PhysicsSteps>,
     physics_time: Res<'_, PhysicsTime>,
-    bevy_time: Res<'_, bevy::core::Time>,
+    bevy_time: Res<'_, bevy::time::Time>,
     mut integration_parameters: ResMut<'_, IntegrationParameters>,
 ) {
     if matches!(

--- a/rapier/src/shape.rs
+++ b/rapier/src/shape.rs
@@ -46,7 +46,7 @@ pub(crate) fn create(
                 rigid_body_handle,
             ))
         } else if let Some((body, rigid_body_handle, material)) =
-            parent.and_then(|p| rigid_bodies.get(p.0).ok())
+            parent.and_then(|p| rigid_bodies.get(p.get()).ok())
         {
             Some((
                 shape.build(

--- a/rapier/tests/bodies.rs
+++ b/rapier/tests/bodies.rs
@@ -1,10 +1,12 @@
 #![cfg(any(dim2, dim3))]
 
+use std::convert::From;
 use std::f32::consts::PI;
 use std::ops::DerefMut;
 use std::time::Duration;
 
 use bevy::core::CorePlugin;
+use bevy::math::Affine3A;
 use bevy::prelude::*;
 use bevy::reflect::TypeRegistryArc;
 
@@ -38,11 +40,7 @@ fn creates_body_in_rapier_world() {
         .insert_bundle((
             RigidBody::Dynamic,
             CollisionShape::Sphere { radius: 2.0 },
-            GlobalTransform {
-                translation,
-                rotation,
-                ..Default::default()
-            },
+            GlobalTransform::from(Affine3A::from_rotation_translation(rotation, translation)),
         ))
         .id();
 
@@ -157,8 +155,12 @@ fn update_rapier_position() {
     {
         app.update();
         let mut transform = app.world.get_mut::<GlobalTransform>(entity).unwrap();
-        transform.translation = translation;
-        transform.rotation = rotation;
+        let (global_scale, _, _) = transform.to_scale_rotation_translation();
+        *transform = GlobalTransform::from(Affine3A::from_scale_rotation_translation(
+            global_scale,
+            rotation,
+            translation,
+        ));
     }
 
     app.update();


### PR DESCRIPTION
Bevy 0.8's GlobalTransform is now backed by an Affine3A, in this PR I just naively convert it back to a transform, rotation and scale when needed using the to_scale_rotation_translation() method. This could cause problems (?), as discussed here: https://github.com/dimforge/bevy_rapier/pull/219

I have not taken the time to work out what problems this could cause, but I assume there needs to be some checks done in some places before assigning to the GlobalTransform.