### PR TITLE
docs(readme): add Bevy 0.8 - Heron 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ It *will* be increased to the latest stable version in a major release. (even if
 
 | bevy | heron      |
 |------|------------|
+| 0.8  | 4          |
 | 0.7  | 3          |
 | 0.6  | 1 - 2      |
 | 0.5  | 0.4 - 0.13 |


### PR DESCRIPTION
This adds the latest version (Bevy 0.8 - Heron 4) to the table under supported versions.