### PR TITLE
Ignore RUSTSEC-2021-0139

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -3,7 +3,9 @@ vulnerability = "deny"
 unmaintained = "deny"
 yanked = "deny"
 notice = "deny"
-ignore = []
+ignore = [
+    "RUSTSEC-2021-0139",
+]
 
 [licenses]
 default = "deny"


### PR DESCRIPTION
It blocked our CI.

We have to wait until https://github.com/tokio-rs/tracing switched to another dependency, just like in bevy: https://github.com/bevyengine/bevy/pull/5816