### PR TITLE
ci: ignore RUSTSEC-2021-0139 (ansi_term used by bevy_log is unmaintained)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -4,7 +4,7 @@ unmaintained = "deny"
 yanked = "deny"
 notice = "deny"
 ignore = [
-    "RUSTSEC-2021-0139", # from ansi_term v0.12.1 - unmaintained - https://github.com/ogham/rust-ansi-term/issues/72
+    "RUSTSEC-2021-0139", # ansi_term, used by bevy_log is unmaintained: https://github.com/ogham/rust-ansi-term/issues/72
 ]
 
 [licenses]

--- a/deny.toml
+++ b/deny.toml
@@ -3,7 +3,9 @@ vulnerability = "deny"
 unmaintained = "deny"
 yanked = "deny"
 notice = "deny"
-ignore = []
+ignore = [
+    "RUSTSEC-2021-0139", # from ansi_term v0.12.1 - unmaintained - https://github.com/ogham/rust-ansi-term/issues/72
+]
 
 [licenses]
 default = "deny"

--- a/deny.toml
+++ b/deny.toml
@@ -4,7 +4,7 @@ unmaintained = "deny"
 yanked = "deny"
 notice = "deny"
 ignore = [
-    "RUSTSEC-2021-0139", # ansi_term, used by bevy_log is unmaintained: https://github.com/ogham/rust-ansi-term/issues/72
+    "RUSTSEC-2021-0139", # ansi_term (used by bevy_log) is unmaintained: https://github.com/ogham/rust-ansi-term/issues/72
 ]
 
 [licenses]


### PR DESCRIPTION
It blocked our CI.

We have to wait until https://github.com/tokio-rs/tracing switched to another dependency, just like in bevy: https://github.com/bevyengine/bevy/pull/5816 