### PR TITLE
Do not add TimePlugin

### DIFF
--- a/rapier/src/lib.rs
+++ b/rapier/src/lib.rs
@@ -23,7 +23,6 @@ pub extern crate rapier3d;
 
 use bevy::ecs::component::Component;
 use bevy::prelude::*;
-use bevy::time::TimePlugin;
 use bevy::transform::TransformSystem;
 #[cfg(dim2)]
 pub(crate) use rapier2d as rapier;
@@ -71,7 +70,6 @@ pub struct ColliderHandle(geometry::ColliderHandle);
 impl Plugin for RapierPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugin(heron_core::CorePlugin)
-            .add_plugin(TimePlugin)
             .init_resource::<PhysicsPipeline>()
             .init_resource::<body::HandleMap>()
             .init_resource::<shape::HandleMap>()
@@ -163,6 +161,7 @@ mod tests {
     use std::time::Duration;
 
     use bevy::core::CorePlugin;
+    use bevy::time::TimePlugin;
 
     use heron_core::{
         Acceleration, CollisionShape, PhysicsSteps, PhysicsTime, RigidBody, Velocity,
@@ -176,6 +175,7 @@ mod tests {
             let mut app = App::new();
 
             app.add_plugin(CorePlugin)
+                .add_plugin(TimePlugin)
                 .add_plugin(TransformPlugin)
                 .add_plugin(RapierPlugin::default())
                 .insert_resource(PhysicsSteps::every_frame(Duration::from_secs(1)));
@@ -213,6 +213,7 @@ mod tests {
     fn does_not_update_rapier_when_paused() {
         let mut app = App::new();
         app.add_plugin(CorePlugin)
+            .add_plugin(TimePlugin)
             .add_plugin(RapierPlugin::default())
             .insert_resource(PhysicsSteps::every_frame(Duration::from_secs(1)));
         let entity = app

--- a/rapier/tests/acceleration.rs
+++ b/rapier/tests/acceleration.rs
@@ -6,6 +6,7 @@ use bevy::core::CorePlugin;
 use bevy::prelude::*;
 use bevy::prelude::{GlobalTransform, Transform};
 use bevy::reflect::TypeRegistryArc;
+use bevy::time::TimePlugin;
 
 use heron_core::{Acceleration, AxisAngle, CollisionShape, PhysicsSteps, RigidBody};
 use heron_rapier::convert::{IntoBevy, IntoRapier};
@@ -20,6 +21,7 @@ fn test_app() -> App {
         .init_resource::<TypeRegistryArc>()
         .insert_resource(PhysicsSteps::every_frame(Duration::from_secs(1)))
         .add_plugin(CorePlugin)
+        .add_plugin(TimePlugin)
         .add_plugin(RapierPlugin);
     builder
 }

--- a/rapier/tests/bodies.rs
+++ b/rapier/tests/bodies.rs
@@ -9,6 +9,7 @@ use bevy::core::CorePlugin;
 use bevy::math::Affine3A;
 use bevy::prelude::*;
 use bevy::reflect::TypeRegistryArc;
+use bevy::time::TimePlugin;
 
 use heron_core::{CollisionShape, PhysicsSteps, PhysicsTime, RigidBody};
 use heron_rapier::convert::{IntoBevy, IntoRapier};
@@ -23,6 +24,7 @@ fn test_app() -> App {
         .init_resource::<TypeRegistryArc>()
         .insert_resource(PhysicsSteps::every_frame(Duration::from_secs(1)))
         .add_plugin(CorePlugin)
+        .add_plugin(TimePlugin)
         .add_plugin(RapierPlugin);
     builder
 }

--- a/rapier/tests/body_types.rs
+++ b/rapier/tests/body_types.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 use bevy::core::CorePlugin;
 use bevy::prelude::*;
 use bevy::reflect::TypeRegistryArc;
+use bevy::time::TimePlugin;
 
 use heron_core::{CollisionShape, PhysicsSteps, RigidBody};
 use heron_rapier::convert::IntoRapier;
@@ -19,6 +20,7 @@ fn test_app() -> App {
         .init_resource::<TypeRegistryArc>()
         .insert_resource(PhysicsSteps::every_frame(Duration::from_secs(1)))
         .add_plugin(CorePlugin)
+        .add_plugin(TimePlugin)
         .add_plugin(RapierPlugin);
     builder
 }

--- a/rapier/tests/children_collision_shapes.rs
+++ b/rapier/tests/children_collision_shapes.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 use bevy::core::CorePlugin;
 use bevy::prelude::*;
 use bevy::reflect::TypeRegistryArc;
+use bevy::time::TimePlugin;
 
 use heron_core::{CollisionShape, PhysicsSteps, RigidBody};
 use heron_rapier::convert::IntoBevy;
@@ -19,6 +20,7 @@ fn test_app() -> App {
         .init_resource::<TypeRegistryArc>()
         .insert_resource(PhysicsSteps::every_frame(Duration::from_secs(1)))
         .add_plugin(CorePlugin)
+        .add_plugin(TimePlugin)
         .add_plugin(RapierPlugin);
 
     builder

--- a/rapier/tests/constraints.rs
+++ b/rapier/tests/constraints.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 use bevy::core::CorePlugin;
 use bevy::prelude::*;
 use bevy::reflect::TypeRegistryArc;
+use bevy::time::TimePlugin;
 
 use heron_core::{CollisionShape, PhysicsSteps, RigidBody, RotationConstraints};
 use heron_rapier::convert::IntoRapier;
@@ -19,6 +20,7 @@ fn test_app() -> App {
         .init_resource::<TypeRegistryArc>()
         .insert_resource(PhysicsSteps::every_frame(Duration::from_secs(1)))
         .add_plugin(CorePlugin)
+        .add_plugin(TimePlugin)
         .add_plugin(RapierPlugin);
     builder
 }

--- a/rapier/tests/damping.rs
+++ b/rapier/tests/damping.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 use bevy::core::CorePlugin;
 use bevy::prelude::*;
 use bevy::reflect::TypeRegistryArc;
+use bevy::time::TimePlugin;
 
 use heron_core::{Damping, PhysicsSteps, RigidBody};
 use heron_rapier::convert::IntoRapier;
@@ -18,6 +19,7 @@ fn test_app() -> App {
     app.init_resource::<TypeRegistryArc>()
         .insert_resource(PhysicsSteps::every_frame(Duration::from_secs(1)))
         .add_plugin(CorePlugin)
+        .add_plugin(TimePlugin)
         .add_plugin(RapierPlugin);
     app
 }

--- a/rapier/tests/density.rs
+++ b/rapier/tests/density.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 use bevy::core::CorePlugin;
 use bevy::prelude::*;
 use bevy::reflect::TypeRegistryArc;
+use bevy::time::TimePlugin;
 
 use heron_core::utils::NearZero;
 use heron_core::{CollisionShape, PhysicMaterial, PhysicsSteps, RigidBody};
@@ -20,6 +21,7 @@ fn test_app() -> App {
         .init_resource::<TypeRegistryArc>()
         .insert_resource(PhysicsSteps::every_frame(Duration::from_secs(1)))
         .add_plugin(CorePlugin)
+        .add_plugin(TimePlugin)
         .add_plugin(RapierPlugin);
     builder
 }

--- a/rapier/tests/events.rs
+++ b/rapier/tests/events.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 use bevy::ecs::event::ManualEventReader;
 use bevy::prelude::*;
 use bevy::reflect::TypeRegistryArc;
+use bevy::time::TimePlugin;
 use bevy::{core::CorePlugin, ecs::event::Events};
 use rstest::*;
 
@@ -20,6 +21,7 @@ fn test_app() -> App {
         .init_resource::<TypeRegistryArc>()
         .insert_resource(PhysicsSteps::every_frame(Duration::from_secs(1)))
         .add_plugin(CorePlugin)
+        .add_plugin(TimePlugin)
         .add_plugin(RapierPlugin)
         .add_system_to_stage(
             bevy::app::CoreStage::PostUpdate,

--- a/rapier/tests/friction.rs
+++ b/rapier/tests/friction.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 use bevy::core::CorePlugin;
 use bevy::prelude::*;
 use bevy::reflect::TypeRegistryArc;
+use bevy::time::TimePlugin;
 
 use heron_core::{CollisionShape, PhysicMaterial, PhysicsSteps, RigidBody};
 use heron_rapier::convert::IntoRapier;
@@ -19,6 +20,7 @@ fn test_app() -> App {
         .init_resource::<TypeRegistryArc>()
         .insert_resource(PhysicsSteps::every_frame(Duration::from_secs(1)))
         .add_plugin(CorePlugin)
+        .add_plugin(TimePlugin)
         .add_plugin(RapierPlugin);
     builder
 }

--- a/rapier/tests/layers.rs
+++ b/rapier/tests/layers.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 use bevy::core::CorePlugin;
 use bevy::prelude::*;
 use bevy::reflect::TypeRegistryArc;
+use bevy::time::TimePlugin;
 
 use heron_core::{CollisionLayers, CollisionShape, PhysicsLayer, PhysicsSteps, RigidBody};
 use heron_rapier::convert::IntoRapier;
@@ -37,6 +38,7 @@ fn test_app() -> App {
         .init_resource::<TypeRegistryArc>()
         .insert_resource(PhysicsSteps::every_frame(Duration::from_secs(1)))
         .add_plugin(CorePlugin)
+        .add_plugin(TimePlugin)
         .add_plugin(RapierPlugin);
     builder
 }

--- a/rapier/tests/resources.rs
+++ b/rapier/tests/resources.rs
@@ -4,6 +4,7 @@ use bevy::app::prelude::*;
 use bevy::core::CorePlugin;
 use bevy::math::prelude::*;
 use bevy::reflect::TypeRegistryArc;
+use bevy::time::TimePlugin;
 
 use heron_core::Gravity;
 use heron_core::PhysicsTime;
@@ -21,6 +22,7 @@ fn can_define_gravity_before_plugin() {
             .insert_resource(Gravity::from(Vec3::Y))
             .init_resource::<TypeRegistryArc>()
             .add_plugin(CorePlugin)
+            .add_plugin(TimePlugin)
             .add_plugin(RapierPlugin::default());
 
         builder

--- a/rapier/tests/restitution.rs
+++ b/rapier/tests/restitution.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 use bevy::core::CorePlugin;
 use bevy::prelude::*;
 use bevy::reflect::TypeRegistryArc;
+use bevy::time::TimePlugin;
 
 use heron_core::{CollisionShape, PhysicMaterial, PhysicsSteps, RigidBody};
 use heron_rapier::convert::IntoRapier;
@@ -19,6 +20,7 @@ fn test_app() -> App {
         .init_resource::<TypeRegistryArc>()
         .insert_resource(PhysicsSteps::every_frame(Duration::from_secs(1)))
         .add_plugin(CorePlugin)
+        .add_plugin(TimePlugin)
         .add_plugin(RapierPlugin);
     builder
 }

--- a/rapier/tests/sensor_shape.rs
+++ b/rapier/tests/sensor_shape.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 use bevy::core::CorePlugin;
 use bevy::prelude::*;
 use bevy::reflect::TypeRegistryArc;
+use bevy::time::TimePlugin;
 
 use heron_core::{CollisionShape, PhysicsSteps, RigidBody, SensorShape};
 use heron_rapier::convert::IntoRapier;
@@ -20,6 +21,7 @@ fn test_app() -> App {
         .init_resource::<TypeRegistryArc>()
         .insert_resource(PhysicsSteps::every_frame(Duration::from_secs(1)))
         .add_plugin(CorePlugin)
+        .add_plugin(TimePlugin)
         .add_plugin(RapierPlugin);
     builder
 }

--- a/rapier/tests/velocity.rs
+++ b/rapier/tests/velocity.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 use bevy::core::CorePlugin;
 use bevy::prelude::*;
 use bevy::reflect::TypeRegistryArc;
+use bevy::time::TimePlugin;
 use rstest::rstest;
 
 use heron_core::*;
@@ -21,6 +22,7 @@ fn test_app() -> App {
         .init_resource::<TypeRegistryArc>()
         .insert_resource(PhysicsSteps::every_frame(Duration::from_secs(1)))
         .add_plugin(CorePlugin)
+        .add_plugin(TimePlugin)
         .add_plugin(RapierPlugin);
     builder
 }


### PR DESCRIPTION
If application adds TimePlugin too, this breaks time delta computation. See [this](https://github.com/jcornaz/heron/pull/301/files#r1018542709) comment for more details.

Applications should add all required plugins before adding heron plugins.