### PR TITLE
feat(heron_rapier): compatibility with `heron_rapier` v5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
           toolchain: ${{ env.RUST_VERSION }}
           profile: minimal
           override: true
-      - run: cargo test -p heron_rapier --no-default-features --features 2d
+      - run: cargo test -p heron_rapier@4.0.0 --no-default-features --features 2d
       - run: cargo test -p heron_debug --no-default-features --features 2d
       - run: cargo test --no-default-features --features 2d
   test-3d:
@@ -66,7 +66,7 @@ jobs:
           profile: minimal
           override: true
       - run: cargo test -p heron_core@4.0.0 --no-default-features --features 3d
-      - run: cargo test -p heron_rapier --no-default-features --features 3d
+      - run: cargo test -p heron_rapier@4.0.0 --no-default-features --features 3d
       - run: cargo test -p heron_debug --no-default-features --features 3d
       - run: cargo test --no-default-features --features 3d
   test-debug-2d:
@@ -101,7 +101,7 @@ jobs:
           toolchain: ${{ env.RUST_VERSION }}
           profile: minimal
           override: true
-      - run: cargo test -p heron_rapier --no-default-features --features enhanced-determinism
+      - run: cargo test -p heron_rapier@4.0.0 --no-default-features --features enhanced-determinism
       - run: cargo test --no-default-features --features enhanced-determinism
   test-collision-from-mesh:
     runs-on: ubuntu-latest

--- a/rapier/Cargo.toml
+++ b/rapier/Cargo.toml
@@ -23,8 +23,6 @@ heron_rapier_v5 = { package = "heron_rapier", version = "5.0" }
 bevy = { version = "0.8.0", default-features = false }
 rapier2d = { version = "0.13.0", optional = true }
 rapier3d = { version = "0.13.0", optional = true }
-fnv = "1.0"
-crossbeam = "0.8.2"
 
 [dev-dependencies]
 rstest = "0.15"

--- a/rapier/Cargo.toml
+++ b/rapier/Cargo.toml
@@ -13,12 +13,13 @@ all-features = true
 
 [features]
 default = []
-2d = ["rapier2d"]
-3d = ["rapier3d", "heron_core/3d"]
-enhanced-determinism = ["rapier2d?/enhanced-determinism", "rapier3d?/enhanced-determinism"]
+2d = ["heron_rapier_v5/2d", "rapier2d"]
+3d = ["heron_rapier_v5/3d", "rapier3d", "heron_core/3d"]
+enhanced-determinism = ["heron_rapier_v5/enhanced-determinism", "rapier2d?/enhanced-determinism", "rapier3d?/enhanced-determinism"]
 
 [dependencies]
 heron_core = { version = "4.0.0", path = "../core" }
+heron_rapier_v5 = { package = "heron_rapier", version = "5.0" }
 bevy = { version = "0.8.0", default-features = false }
 rapier2d = { version = "0.13.0", optional = true }
 rapier3d = { version = "0.13.0", optional = true }

--- a/rapier/src/lib.rs
+++ b/rapier/src/lib.rs
@@ -13,8 +13,6 @@
 //!
 //! The following types are accepted as [`heron_core::CustomCollisionShape`]
 //! values.
-//!
-//! - [`rapier::geometry::ColliderBuilder`]
 
 #[cfg(feature = "rapier2d")]
 pub extern crate rapier2d;

--- a/rapier/src/lib.rs
+++ b/rapier/src/lib.rs
@@ -21,141 +21,24 @@ pub extern crate rapier2d;
 #[cfg(feature = "rapier3d")]
 pub extern crate rapier3d;
 
-use bevy::ecs::component::Component;
 use bevy::prelude::*;
 use bevy::time::TimePlugin;
-use bevy::transform::TransformSystem;
-#[cfg(dim2)]
-pub(crate) use rapier2d as rapier;
-#[cfg(dim3)]
-pub(crate) use rapier3d as rapier;
 
-use heron_core::{CollisionEvent, PhysicsSystem};
-pub use pipeline::{PhysicsWorld, RayCastInfo, ShapeCastCollisionInfo, ShapeCastCollisionType};
-
-use crate::rapier::dynamics::{
-    self, CCDSolver, ImpulseJointSet, IntegrationParameters, IslandManager, MultibodyJointSet,
-    RigidBodySet,
+pub use heron_rapier_v5::{
+    convert, nalgebra, ColliderHandle, PhysicsWorld, RayCastInfo, RigidBodyHandle,
+    ShapeCastCollisionInfo, ShapeCastCollisionType,
 };
-use crate::rapier::geometry::{self, BroadPhase, ColliderSet, NarrowPhase};
-pub use crate::rapier::na as nalgebra;
-use crate::rapier::pipeline::{PhysicsPipeline, QueryPipeline};
-
-mod acceleration;
-mod body;
-pub mod convert;
-mod damping;
-mod pipeline;
-mod shape;
-mod velocity;
 
 /// Plugin that enables collision detection and physics behavior, powered by rapier.
 #[must_use]
 #[derive(Debug, Copy, Clone, Default)]
 pub struct RapierPlugin;
 
-/// Component that holds a reference to the rapier rigid body
-///
-/// It is automatically inserted and removed by heron.
-/// It is only useful for advanced, direct access to the rapier world
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Component)]
-pub struct RigidBodyHandle(dynamics::RigidBodyHandle);
-
-/// Component that holds a reference to the rapier collider
-///
-/// It is automatically inserted and removed by heron.
-/// It is only useful for advanced, direct access to the rapier world
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Component)]
-pub struct ColliderHandle(geometry::ColliderHandle);
-
 impl Plugin for RapierPlugin {
     fn build(&self, app: &mut App) {
-        app.add_plugin(heron_core::CorePlugin)
-            .add_plugin(TimePlugin)
-            .init_resource::<PhysicsPipeline>()
-            .init_resource::<body::HandleMap>()
-            .init_resource::<shape::HandleMap>()
-            .init_resource::<IntegrationParameters>()
-            .add_event::<CollisionEvent>()
-            .insert_resource(BroadPhase::new())
-            .insert_resource(NarrowPhase::new())
-            .insert_resource(RigidBodySet::new())
-            .insert_resource(QueryPipeline::new())
-            .insert_resource(IslandManager::new())
-            .insert_resource(ColliderSet::new())
-            .insert_resource(ImpulseJointSet::new())
-            .insert_resource(MultibodyJointSet::new())
-            .insert_resource(CCDSolver::new())
-            .stage("heron-physics", |schedule: &mut Schedule| {
-                schedule
-                    .add_stage("heron-remove", removal_stage())
-                    .add_stage("heron-update-rapier-world", update_rapier_world_stage())
-                    .add_stage("heron-create-new-bodies", body_update_stage())
-                    .add_stage("heron-create-new-colliders", create_collider_stage())
-            })
-            .add_system_set_to_stage(CoreStage::PostUpdate, step_systems());
+        app.add_plugin(TimePlugin)
+            .add_plugin(heron_rapier_v5::RapierPlugin::default());
     }
-}
-
-fn removal_stage() -> SystemStage {
-    SystemStage::single_threaded()
-        .with_system(body::remove_invalids_after_components_removed)
-        .with_system(shape::remove_invalids_after_components_removed)
-        .with_system(body::remove_invalids_after_component_changed)
-        .with_system(shape::remove_invalids_after_component_changed)
-}
-
-fn update_rapier_world_stage() -> SystemStage {
-    SystemStage::parallel()
-        .with_run_criteria(heron_core::should_run)
-        .with_system(bevy::transform::transform_propagate_system)
-        .with_system(
-            body::update_rapier_position.after(bevy::transform::transform_propagate_system),
-        )
-        .with_system(velocity::update_rapier_velocity)
-        .with_system(acceleration::update_rapier_force_and_torque)
-        .with_system(damping::update_rapier_damping)
-        .with_system(damping::reset_rapier_damping)
-        .with_system(shape::update_position)
-        .with_system(shape::update_collision_groups)
-        .with_system(shape::update_sensor_flag)
-        .with_system(shape::remove_sensor_flag)
-        .with_system(shape::reset_collision_groups)
-}
-
-fn body_update_stage() -> SystemStage {
-    SystemStage::single_threaded()
-        .with_run_criteria(heron_core::should_run)
-        .with_system(body::create)
-}
-
-fn create_collider_stage() -> SystemStage {
-    SystemStage::single_threaded()
-        .with_run_criteria(heron_core::should_run)
-        .with_system(shape::create)
-}
-
-fn step_systems() -> SystemSet {
-    SystemSet::new()
-        .with_run_criteria(heron_core::should_run)
-        .with_system(pipeline::update_integration_parameters.before(PhysicsSystem::Events))
-        .with_system(pipeline::step.label(PhysicsSystem::Events))
-        .with_system(
-            body::update_bevy_transform
-                .label(PhysicsSystem::TransformUpdate)
-                .after(PhysicsSystem::Events)
-                .before(TransformSystem::TransformPropagate),
-        )
-        .with_system(
-            velocity::update_velocity_component
-                .label(PhysicsSystem::VelocityUpdate)
-                .after(PhysicsSystem::Events),
-        )
-        .with_system(
-            velocity::update_rapier_velocity
-                .after(PhysicsSystem::Events)
-                .after(PhysicsSystem::VelocityUpdate),
-        )
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Make the `heron_rapier 4` to re-export most of `heron_rapier 5` (except for `RapierPlugin` which received the breaking change). 

This is also known as the [semver trick](https://github.com/dtolnay/semver-trick), and it makes most code depending on `heron_rapier 4` automatically compatible with `heron_rapier 5` and vice versa.
